### PR TITLE
docs(#34): /docs technical documentation + ADRs + wiki sync

### DIFF
--- a/.github/workflows/sync-docs-to-wiki.yml
+++ b/.github/workflows/sync-docs-to-wiki.yml
@@ -1,0 +1,55 @@
+name: Sync docs to wiki
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'docs/**'
+      - 'scripts/docs/sync-to-wiki.js'
+      - '.github/workflows/sync-docs-to-wiki.yml'
+
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate docs
+        run: |
+          node scripts/docs/check-index.js
+          node scripts/docs/check-links.js
+
+      - name: Clone wiki
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.wiki.git" wiki
+
+      - name: Sync docs/ → wiki/
+        run: node scripts/docs/sync-to-wiki.js docs wiki
+
+      - name: Commit and push
+        working-directory: wiki
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Wiki is already up to date."
+          else
+            git commit -m "docs: sync from ${{ github.sha }}"
+            git push
+          fi

--- a/.github/workflows/sync-docs-to-wiki.yml
+++ b/.github/workflows/sync-docs-to-wiki.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Clone wiki
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.WIKI_TOKEN }}
         run: |
           git clone "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.wiki.git" wiki
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,20 @@ stages:
   - test
   - build
 
+docs-validate:
+  stage: test
+  image: harbor.eli-beams.eu/proxy-dockerhub/node:20.18-alpine
+  services: []
+  variables:
+    DOCKER_TLS_CERTDIR: ""
+  script:
+    - node scripts/docs/check-index.js
+    - node scripts/docs/check-links.js
+  rules:
+    - changes:
+        - docs/**/*
+        - scripts/docs/**/*
+
 variables:
   # When you use the dind service, you must instruct Docker to talk with
   # the daemon started inside of the service. The daemon is available

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Guidance for coding agents (Claude Code etc.) working in this repository.
 
+For architecture, runbooks, ADRs, and the canonical map of the codebase, start at [`/docs/`](./docs/README.md). Wiki mirror: published to the GitHub Wiki on push to `dev`.
+
 ## Workflow
 
 - When entering plan mode or producing any implementation plan, invoke the `tdd` skill and structure the plan around it: failing test first, minimal code to pass, refactor.

--- a/backend/mockup-websocket-server/readme.md
+++ b/backend/mockup-websocket-server/readme.md
@@ -1,6 +1,6 @@
-Thought for 8 seconds
-
 # Mock-up EPICS WebSocket Gateway
+
+> Architecture context: [`docs/backend/mock-server.md`](../../docs/backend/mock-server.md). Mock-vs-Python split recorded in [ADR-0005](../../docs/adr/0005-mock-vs-python-backend-split.md). Run: [`docs/runbooks/running-mock-backend.md`](../../docs/runbooks/running-mock-backend.md).
 
 A lightweight Go service that fakes an EPICS gateway:
 

--- a/backend/python-websocket-server/README.md
+++ b/backend/python-websocket-server/README.md
@@ -1,5 +1,7 @@
 # EPICS WebSocket Server
 
+> Architecture context: [`docs/backend/python-server.md`](../../docs/backend/python-server.md). WS protocol divergence vs the mock: [`docs/backend/websocket-protocol.md`](../../docs/backend/websocket-protocol.md) and [ADR-0009](../../docs/adr/0009-shared-ws-protocol-contract.md). Run/deploy: [`docs/runbooks/running-python-backend.md`](../../docs/runbooks/running-python-backend.md), [`docs/runbooks/deploying-python-backend.md`](../../docs/runbooks/deploying-python-backend.md).
+
 This service exposes a production-oriented FastAPI gateway in front of EPICS using aioca. The current scope is read and monitor operations only.
 
 ## Root Landing Page

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,62 @@
+# Documentation
+
+Canonical, in-repo map of the **eli-hmi** stack: Next.js frontend, Go mock backend, Python FastAPI/aioca backend.
+
+This tree mirrors to the [GitHub Wiki](https://github.com/eli-eric/eli-hmi/wiki) on every push to `dev` ([sync action](workflows/publishing-wiki.md)).
+
+## Start here
+
+- [Architecture](architecture.md) — all three modules and the seams between them
+- [Glossary](glossary.md) — domain (PV, EPICS, …) ⨯ architecture vocabulary
+- [Context](context.md) — `CONTEXT.md` shape for the [improve-codebase-architecture skill](../.agents/skills/improve-codebase-architecture/SKILL.md)
+
+## Frontend
+
+- [Overview](frontend/overview.md)
+- [WebSocket client](frontend/websocket-client.md)
+- [Module pages](frontend/module-pages.md)
+- [HMI components](frontend/hmi-components.md)
+- [Auth](frontend/auth.md)
+- [Zones](frontend/zones.md)
+- [L4 OPCPA](frontend/l4-opcpa.md)
+
+## Backend
+
+- [Overview](backend/overview.md)
+- [Mock server (Go)](backend/mock-server.md)
+- [Python server (FastAPI + aioca)](backend/python-server.md)
+- [WebSocket protocol](backend/websocket-protocol.md)
+- [PV write endpoint](backend/pv-write-endpoint.md)
+
+## Reference
+
+- [PV naming](reference/pv-naming.md)
+- [Env vars](reference/env-vars.md)
+
+## Runbooks
+
+- [Local dev](runbooks/local-dev.md)
+- [Running the mock backend](runbooks/running-mock-backend.md)
+- [Running the Python backend](runbooks/running-python-backend.md)
+- [Deploying the Python backend](runbooks/deploying-python-backend.md)
+- [Operator stations](runbooks/operator-stations.md)
+
+## ADRs
+
+- [Template](adr/template.md)
+- [ADR-0001 WS pub/sub pattern](adr/0001-ws-pubsub-pattern.md)
+- [ADR-0002 Zone-based access control](adr/0002-zone-based-access-control.md)
+- [ADR-0003 Compound components for HMI panels](adr/0003-compound-components-for-hmi-panels.md)
+- [ADR-0004 Single PV write endpoint](adr/0004-single-pv-write-endpoint.md)
+- [ADR-0005 Mock vs Python backend split](adr/0005-mock-vs-python-backend-split.md)
+- [ADR-0006 PV name registry (L4 OPCPA)](adr/0006-pv-name-registry-l4-opcpa.md)
+- [ADR-0007 L4 custom shell, not ModuleControlPage](adr/0007-l4-custom-shell-not-modulecontrolpage.md)
+- [ADR-0008 Laser specs location](adr/0008-laser-specs-location.md)
+- [ADR-0009 Shared WS protocol contract](adr/0009-shared-ws-protocol-contract.md)
+
+## Workflows
+
+- [Adding a control page](workflows/adding-a-control-page.md)
+- [Adding a PV to the mock backend](workflows/adding-a-pv-to-mock-backend.md)
+- [Adding an ADR](workflows/adding-an-adr.md)
+- [Publishing wiki](workflows/publishing-wiki.md)

--- a/docs/adr/0001-ws-pubsub-pattern.md
+++ b/docs/adr/0001-ws-pubsub-pattern.md
@@ -1,0 +1,34 @@
+# ADR-0001: WebSocket pub/sub for EPICS PVs
+
+**Status:** Accepted
+**Date:** 2025-04-30
+**Deciders:** ELI-HMI team
+
+## Context
+
+The HMI needs live PV values from EPICS in a browser. Three options were on the table:
+
+1. Polling HTTP GETs per PV
+2. EPICS Channel Access directly from the browser (not viable — no JS CA client)
+3. A backend that proxies CA into a single browser-facing WebSocket
+
+Operator pages subscribe to dozens of PVs. Polling would explode the request count and either lag (long intervals) or hammer the backend (short intervals). EPICS pushes its own updates already; we want to surface them, not re-discover them.
+
+## Decision
+
+A single app-wide WebSocket connection per browser tab. The frontend WS client (`useWebSocket` + `useWebSocketContext`) is a deep **module** behind one **interface** (`useWebSocketData(pv|{pvs:[]})`). Subscriptions are stored in a ref-backed map and replayed on every reconnect via `replaySubscriptions()`. The NextAuth JWT is carried as `?auth=<token>` on the upgrade URL — browsers cannot attach an `Authorization` header to a WebSocket upgrade.
+
+The backend side has two **adapters** at this **seam**: the Go mock and the Python FastAPI server. Two adapters means the seam is real, not hypothetical.
+
+## Consequences
+
+- **Positive — leverage.** One pattern fits every PV consumer. Reconnect, replay, dedup, prefix mapping, and typed envelopes live in one place.
+- **Positive — locality.** All connection-lifecycle bugs concentrate in `useWebSocket`. The test surface is the hook's interface.
+- **Negative.** Browsers can't carry auth in headers on WS upgrade, so the JWT is on the URL. URL-borne tokens leak into server logs unless logs are scrubbed; verify your log pipeline.
+- **Open.** The two adapters do not currently satisfy the same frame contract — see [ADR-0009](0009-shared-ws-protocol-contract.md).
+
+## Alternatives considered
+
+- **Per-page WS connections.** Rejected — N pages × M PVs × reconnect = N×M reconnect storms; defeats the dedup leverage.
+- **Server-Sent Events.** No client→server channel without a parallel HTTP request, so subscribe/unsubscribe lifecycles become awkward.
+- **GraphQL subscriptions.** Same shape via a heavier transport; the EPICS payload is too simple to justify a typed query layer.

--- a/docs/adr/0002-zone-based-access-control.md
+++ b/docs/adr/0002-zone-based-access-control.md
@@ -1,0 +1,31 @@
+# ADR-0002: Zone-based access control
+
+**Status:** Accepted
+**Date:** 2025-04-30
+**Deciders:** ELI-HMI team
+
+## Context
+
+The same frontend bundle serves multiple physical control rooms. Each station should only reach the pages relevant to its hardware. We needed a way to gate routes that is:
+
+- **Tamper-resistant** at runtime — operators shouldn't be able to URL-poke into other modules.
+- **Auditable** — a deployed station's allowed pages are inspectable from one file.
+- **Cheap** — no per-request DB lookup.
+
+## Decision
+
+A build-time **zone** keyed by `NEXT_PUBLIC_ZONE_CODE`. The zone descriptor (`{navigationItems, allowedRoutes}`) lives in `src/lib/settings/zone-config.ts` — that file is the **interface**. The **adapter** is `src/middleware.ts`, which 302-redirects any request whose path isn't in `allowedRoutes` to `/no-access`. The nav bar reads the same config.
+
+`NEXT_PUBLIC_*` is baked into the bundle at build time — there is no runtime zone switch. Switching zones means a rebuild.
+
+## Consequences
+
+- **Positive — locality.** All access-control bugs concentrate in `middleware.ts` + `zone-config.ts`. The middleware is in the [coverage gate](../frontend/overview.md#coverage-gate).
+- **Positive — leverage.** New pages are gated for free by adding a string to `allowedRoutes`; no per-route code.
+- **Negative — operational.** The shipped `production` zone is intentionally empty, which means *every* production deployment must supply a per-site zone at build time. This is documented in [zones](../frontend/zones.md) but is the single most common deployment mistake.
+- **Open.** Per-user access (separate from per-station) is out of scope. If/when needed, layer over zones rather than replace them.
+
+## Alternatives considered
+
+- **Runtime config served from the backend.** Rejected — adds a request before any page renders; complicates middleware; loses build-time auditability.
+- **Per-user role-based auth.** Rejected for now — the operational model is "station-as-role." If user-level granularity becomes necessary, add it as a second check inside the middleware without removing the zone gate.

--- a/docs/adr/0003-compound-components-for-hmi-panels.md
+++ b/docs/adr/0003-compound-components-for-hmi-panels.md
@@ -1,0 +1,31 @@
+# ADR-0003: Compound components for HMI panels
+
+**Status:** Accepted
+**Date:** 2025-06-15
+**Deciders:** ELI-HMI team
+
+## Context
+
+The audience for new pages is control-system engineers, not React specialists. A control page wires dozens of PVs into specific layouts (volumes, connectors, valves, sensor bars, laser sections). Two earlier shapes were considered:
+
+1. **Atomic props-driven components.** Every panel exposes its full shape as nested props. The result is multi-screen prop literals that are hard to read and trivially wrong.
+2. **Imperative children.** Each panel accepts opaque children but caller manages state. State sprawl across pages.
+
+## Decision
+
+Compound-component pattern: a parent attaches subcomponents as static properties (`VolumePanel.SensorBar`, `LaserPanel.Regen`). Composition is declarative; state lives inside the compound parent (via context) where appropriate. Engineers wire **PV names**, not React state.
+
+Affected **modules**: `VolumePanel`, `ConnectorLine`, `LaserPanel`. The reusable `controls/` primitives (`SectionCard`, `DataRow`, `usePvWrite`, `ActionButton`, `PresetIntegerInput`, `CogToggle`) share the same authoring discipline without requiring a single compound parent.
+
+## Consequences
+
+- **Positive — leverage.** Engineers compose pages from a small dot-namespaced grammar. The author does not need to know React state management.
+- **Positive — locality.** Bugs in panel logic concentrate in the panel's directory rather than propagating across pages.
+- **Negative.** Compound components are not the React community default; new contributors need to learn the pattern. The compound parent uses context which TypeScript-savvy contributors expect to find explicitly.
+- **Open.** Filename casing varies across HMI directories — see the AGENTS.md carve-out and [issue #33 / commit `e9965be`](../../frontend/AGENTS.md). Not a refactor target; documented and bounded.
+
+## Alternatives considered
+
+- **Atomic + JSX schema.** Rejected — pushes too much shape into props.
+- **Headless UI library with render-props.** Rejected — adds an external dependency for a domain that prefers in-house primitives.
+- **Per-page bespoke components from day 1.** Rejected — defeats the reuse motive; engineers would re-discover the same patterns per page.

--- a/docs/adr/0004-single-pv-write-endpoint.md
+++ b/docs/adr/0004-single-pv-write-endpoint.md
@@ -1,0 +1,32 @@
+# ADR-0004: Single PV write endpoint
+
+**Status:** Accepted
+**Date:** 2025-09-01
+**Deciders:** ELI-HMI team (L4 OPCPA workstream)
+
+## Context
+
+The L4 OPCPA work introduced dozens of write paths: start/stop laser, change attenuation, load waveform, toggle shutter, set chiller setpoint, …. Initial designs sketched per-action endpoints (`/laser/start`, `/laser/stop`, `/laser/shutter`). Two problems:
+
+- **Surface growth.** Every new control on the page meant a new endpoint, a new handler on the backend, a new client function. Three modules to touch per button.
+- **Cross-cutting concerns.** Auth, retry, audit, error UX, failure injection, telemetry — each repeated per endpoint.
+
+## Decision
+
+Every UI mutation is one HTTP shape: `POST /pv/<NAME>` with `{value: …}` and an `Authorization` header. Some PVs are "command PVs" (`CMD_<L>_<NAME>`) whose backend handler dispatches a coordinated effect chain (e.g. `start_laser` writes 25+ PVs). The frontend treats CMD PVs as fire-and-forget triggers — same write **interface**, server-side dispatch.
+
+The client-side **adapter** is `pvWrite()` (`src/lib/api/pvs.ts`), consumed via the `usePvWrite()` hook by every write control.
+
+## Consequences
+
+- **Positive — leverage.** Adding a button on the frontend equals adding a row in the backend's PV table. No API surface change.
+- **Positive — locality.** Audit, retry, logging, failure-injection, error toasts — all in `pvWrite` and `usePvWrite`.
+- **Negative — coupling.** Effect-chain behaviour hides on the server. The frontend cannot anticipate what writing `CMD_<L>_START_LASER` will do beyond "trigger start." Acceptable because operators don't need to: the spec defines the chain semantics in [Confluence](https://eli-eric.atlassian.net/wiki/spaces/CS/pages/2333902150).
+- **Open.** The Python backend has not yet implemented this endpoint — it is currently read/monitor only. When it does, it must honor this contract.
+- **Open.** Two pre-existing call sites (`WarningErrorControl.tsx`, `DropDownStateControl.tsx`) bypass `pvWrite()` and call `fetch` + `getPrefixedPV` directly. They should migrate; tracked in [context.md](../context.md#what-good-deepening-looks-like-here).
+
+## Alternatives considered
+
+- **Per-action REST endpoints.** Rejected — surface growth.
+- **GraphQL mutations.** Rejected — the action shape is trivial; a typed query layer is overkill.
+- **WebSocket-only writes.** Rejected — HTTP gives free auth header handling and standard retry semantics; we already pay the WS cost for reads.

--- a/docs/adr/0005-mock-vs-python-backend-split.md
+++ b/docs/adr/0005-mock-vs-python-backend-split.md
@@ -1,0 +1,36 @@
+# ADR-0005: Mock vs Python backend split
+
+**Status:** Accepted
+**Date:** 2025-05-01
+**Deciders:** ELI-HMI team
+
+## Context
+
+Frontend development should not block on EPICS network access. The production backend needs the EPICS C library, an aioca-compatible runtime, and a route to a live IOC. None of that is appropriate for a laptop or CI runner.
+
+Earlier prototypes shared one Python codebase between dev (in-process fake) and prod (real EPICS). Two issues:
+
+- The fake had to be guarded by `if MOCK_MODE`, which leaked through interfaces.
+- Onboarding required setting up a Python environment with EPICS bindings before any frontend work.
+
+## Decision
+
+Two backends as **distinct modules**:
+
+- **Mock (`backend/mockup-websocket-server/`, Go).** Synthesises PVs from name-prefix conventions (`AI_*` float, `BI_*` bool, `SI_*` string). Single binary, no deps. Used in local dev and frontend integration tests.
+- **Python (`backend/python-websocket-server/`, FastAPI + aioca).** Production target. Talks to a real EPICS network.
+
+The frontend points at one or the other via `NEXT_PUBLIC_API_URL`. The frontend's WS client is the **adapter** on its side of the **seam**.
+
+## Consequences
+
+- **Positive — locality.** Each backend's complexity stays in its own tree. The Go binary has no aioca dependency; the Python server has no synthetic-drift loop.
+- **Positive — leverage.** Onboarding a frontend contributor is `go run main.go` + `npm run dev`. No Python toolchain required.
+- **Negative — drift risk.** Two adapters at one seam can diverge. They have — see [ADR-0009](0009-shared-ws-protocol-contract.md). The L4 OPCPA work added explicit "keep the registries in sync" discipline ([ADR-0006](0006-pv-name-registry-l4-opcpa.md)) to address one such drift.
+- **Negative — convention coupling.** The mock's prefix conventions (`AI_*` / `BI_*` / `SI_*`) are not how real EPICS names PVs. Frontend code written against the mock may accidentally encode these conventions and break on the real network.
+
+## Alternatives considered
+
+- **One backend with a mode flag.** Rejected — the per-mode `if` branches polluted the codebase. The deletion test pushes the other way.
+- **EPICS soft IOC for local dev.** Considered — viable but raises onboarding floor (every contributor installs EPICS Base). Worth revisiting if the synthetic-drift convention causes ongoing bugs.
+- **Recording / replaying real EPICS traffic.** Rejected — captures one moment in time; recordings rot.

--- a/docs/adr/0006-pv-name-registry-l4-opcpa.md
+++ b/docs/adr/0006-pv-name-registry-l4-opcpa.md
@@ -1,0 +1,39 @@
+# ADR-0006: PV name registry for L4 OPCPA
+
+**Status:** Accepted
+**Date:** 2025-09-15
+**Deciders:** ELI-HMI team (L4 OPCPA workstream)
+
+## Context
+
+L4 OPCPA wires hundreds of PVs across 5 lasers × 5 sections (General, Regen, Chillers, Flashlamps, Modbox) × per-laser topology. Initial code used inline string templates:
+
+```ts
+const shutterPv = `BI_${laser}_SHUTTER`
+```
+
+Three problems:
+
+- **No type safety.** Typos surface only as runtime "PV not found" frames.
+- **Mock mirror drift.** The Go mock hand-mirrors every L4 PV in `l4_opcpa.go`. With inline templates on the frontend, the canonical naming convention had no home — the mock and frontend could drift silently.
+- **No refactor handle.** Renaming a PV family meant grepping for inline strings across two codebases.
+
+## Decision
+
+Every L4 OPCPA PV name is constructed via a typed builder in `frontend/src/app/(modules)/l4-opcpa/lib/pv-names.ts`. The file is the **canonical source** for L4 PV-name shapes. Tests in `pv-names.test.ts` lock the wire-name format.
+
+The mock backend (`backend/mockup-websocket-server/l4_opcpa.go`) hand-mirrors the same shapes. A header comment in `l4_opcpa.go` points back to `pv-names.ts`. Keeping them in sync is part of the workflow — see [adding-a-pv-to-mock-backend](../workflows/adding-a-pv-to-mock-backend.md#case-3-l4-opcpa-pv).
+
+## Consequences
+
+- **Positive — locality.** PV-name conventions live in one file. The mock either matches or fails tests at integration time.
+- **Positive — leverage.** Typos become type errors; renames are one file edit.
+- **Positive — readability.** `pv.cmd('NL2', 'START_LASER')` reads better than the equivalent string literal at every call site.
+- **Negative — coupling.** The registry encodes mock-convention prefixes (`BI_*`, `AI_*`, `CMD_*`) that are not how a production EPICS network names PVs. When the python-backend gains writes, either the registry indirects (adapter under the hood) or the production EPICS database adopts these names (the team's stated plan).
+- **Open.** No automatic check that the Go mock's mirror is in sync with `pv-names.ts`. A cross-codebase test or codegen step could close this gap.
+
+## Alternatives considered
+
+- **Codegen from a schema.** Considered — viable; deferred until the team agrees on the canonical naming convention with the EPICS DB owners.
+- **Inline strings + lint rule.** Rejected — would catch typos but not refactor cleanly.
+- **PV registry on the mock as canonical.** Rejected — the mock is a development tool; the frontend's logical names should be the source of truth.

--- a/docs/adr/0007-l4-custom-shell-not-modulecontrolpage.md
+++ b/docs/adr/0007-l4-custom-shell-not-modulecontrolpage.md
@@ -1,0 +1,30 @@
+# ADR-0007: L4 OPCPA uses a custom page shell, not `ModuleControlPage`
+
+**Status:** Accepted
+**Date:** 2025-09-15
+**Deciders:** ELI-HMI team (L4 OPCPA workstream)
+
+## Context
+
+The L3BT, L4fBT, and P3 control pages render through one shared shell — `<ModuleControlPage>` — driven by a typed `ModuleConfig`. That shell is opinionated around vacuum systems: interlocks, safety permission, clean-dry-air, backing, roughing, plus a bespoke bottom row.
+
+L4 OPCPA is a different domain. The wireframe specifies a flat 5-column grid of laser status panels — General / Regen / Chillers / Flashlamps / Modbox — with no top/bottom ribbons. Forcing it into `ModuleControlPage` would mean stubbing every vacuum-specific panel.
+
+## Decision
+
+L4 OPCPA has its own page shell at `frontend/src/app/(modules)/l4-opcpa/page.tsx`. It composes the (shared) `LaserPanel` compound component and the (shared) `controls/` primitives directly. It does **not** call `<ModuleControlPage>` and does **not** declare a `ModuleConfig`.
+
+The shared `LaserPanel` and `controls/` modules are usable by future laser-control pages — the opt-out is the *page shell*, not the components.
+
+## Consequences
+
+- **Positive — leverage.** L4 OPCPA gets a layout that fits its domain. `LaserPanel` + `controls/` remain reusable by any future laser page.
+- **Positive — locality.** Each shell concentrates the layout decisions for its domain. Adding a vacuum control page doesn't risk breaking laser layout, and vice versa.
+- **Negative.** Two page shells means two patterns to teach. New contributors must recognise which one to start from. The L4 OPCPA README and [frontend/l4-opcpa](../frontend/l4-opcpa.md) are explicit about why.
+- **Open.** If a third domain appears (e.g. cryogenics), a third shell is acceptable; resist the pull to generalise prematurely. *One adapter means a hypothetical seam; two adapters means a real one.*
+
+## Alternatives considered
+
+- **Force L4 into `ModuleControlPage` with stub panels.** Rejected — stubs add complexity for no leverage; the wireframe explicitly diverges.
+- **Generalise `ModuleControlPage` into a `<DomainShell>` abstraction.** Rejected — premature. We have two shells; generalisation would require a third use case to test the abstraction.
+- **Per-laser pages.** Rejected — operators want all 5 lasers visible side-by-side; a per-laser route is the wrong UX.

--- a/docs/adr/0008-laser-specs-location.md
+++ b/docs/adr/0008-laser-specs-location.md
@@ -1,0 +1,33 @@
+# ADR-0008: `LASER_SPECS` lives under L4 OPCPA, not under `lib/modules/`
+
+**Status:** Accepted
+**Date:** 2025-09-20
+**Deciders:** ELI-HMI team (L4 OPCPA workstream)
+
+## Context
+
+L4 OPCPA's page renders 5 lasers, each from a `LaserSpec` describing per-laser **topology**: number of MSS items, chiller IDs, flashlamp box IDs, delay presets, modbox state count. The natural question: should this config live in `frontend/src/lib/modules/` next to `l3bt.config.ts`, `l4fbt.config.ts`, `p3.config.ts`?
+
+## Decision
+
+No. `LASER_SPECS` lives at `frontend/src/app/(modules)/l4-opcpa/components/laser-specs.ts`, under the L4 OPCPA module. `lib/modules/` is reserved for `ModuleConfig` — the typed shape consumed by `<ModuleControlPage>` ([ADR-0007](0007-l4-custom-shell-not-modulecontrolpage.md)).
+
+The two configs describe **different concepts**:
+
+- `ModuleConfig` — layout shape (which vacuum panels exist, with which PVs).
+- `LaserSpec` — topology (how many of each thing exist for this laser).
+
+Mixing them in `lib/modules/` would conflate independent things and force every consumer of one to learn the other's shape.
+
+## Consequences
+
+- **Positive — locality.** L4-specific topology stays with L4 code. The shared `lib/modules/` directory keeps its single meaning.
+- **Positive — readability.** Future readers don't have to mentally separate "layout config" from "topology config" inside one directory.
+- **Negative — discoverability.** A new contributor looking for "where are module configs?" might miss `laser-specs.ts`. Mitigated by [l4-opcpa](../frontend/l4-opcpa.md) and the L4 OPCPA README naming it explicitly.
+- **Open.** When (or if) a Python EPICS gateway exposes `GET /lasers`, this static config should be replaced with a fetch and topology becomes the canonical source — at that point the file disappears. Tracked at the bottom of `frontend/src/app/(modules)/l4-opcpa/README.md`.
+
+## Alternatives considered
+
+- **Put `LASER_SPECS` under `lib/modules/`.** Rejected — different concept; would erode the meaning of that directory.
+- **A new shared `lib/topology/` directory.** Rejected — premature; we have one topology config. *One adapter means a hypothetical seam.*
+- **Inline `LASER_SPECS` into `page.tsx`.** Rejected — testability suffers; `LASER_SPECS` is iterated to render the grid and is the natural seam for "swap to a real endpoint later."

--- a/docs/adr/0009-shared-ws-protocol-contract.md
+++ b/docs/adr/0009-shared-ws-protocol-contract.md
@@ -1,0 +1,44 @@
+# ADR-0009: Shared WebSocket protocol contract
+
+**Status:** Open
+**Date:** 2026-05-13
+**Deciders:** ELI-HMI team
+
+## Context
+
+The two backend adapters at the `/ws/pvs` **seam** do not satisfy the same frame contract. Detail in [backend/websocket-protocol](../backend/websocket-protocol.md).
+
+| Aspect | Mock (Go) | Python (FastAPI) | Frontend client |
+| --- | --- | --- | --- |
+| `pvs` shape on subscribe | object `{NAME:true}` | array `[NAME]` | object `{NAME:true}` |
+| `subscription_id` | absent | required | absent |
+| Initial value frame | normal `pv` | dedicated `snapshot` | parses `pv` only |
+| Updates | `pv` | `event` | parses `pv` only |
+| Connection ack | none | `connected` (with limits) | ignored |
+
+In practice, the frontend works against the mock and does not work against the Python server. The Python server is the **production target** ([ADR-0005](0005-mock-vs-python-backend-split.md)), so this is a real ship blocker.
+
+## Decision
+
+**Not yet decided.** This ADR exists to (1) freeze the gap as an explicit architectural debt, (2) prevent ad-hoc shimming during unrelated changes, and (3) name the three options.
+
+Options:
+
+1. **Adopt the Python dialect on the frontend** (and emulate it in the mock).
+   Highest leverage long-term — the Python server's richer surface (`subscription_id`, separate `snapshot`/`event`, `connected` limits, ping/pong) is genuinely useful. Biggest one-time change.
+2. **Add a compatibility shim to the Python server.**
+   Easiest to land. Pushes the dialect-translation complexity into the server, which is the wrong direction — the server learns the dialects of its clients.
+3. **Define a third, deliberate contract** and migrate both adapters.
+   Best vocabulary; most coordination. Right answer if the team takes this seriously enough to write it down once.
+
+This ADR will be updated to *Accepted* once an option is chosen. Until then, do not silently expand the divergence — every new WS frame change on either side must be reflected in the matching adapter or in [backend/websocket-protocol](../backend/websocket-protocol.md).
+
+## Consequences
+
+- **Positive (when accepted).** A single named contract makes the seam testable end-to-end across both adapters.
+- **Negative (status quo).** The frontend cannot consume the Python server, so production deployment is gated on resolving this.
+- **Open — the whole point.** Pick option 1, 2, or 3.
+
+## Alternatives considered
+
+(Same as the three options above; this ADR is the meta-decision to *decide*, not the decision itself.)

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,23 @@
+# ADR-NNNN: \<title\>
+
+**Status:** Accepted | Superseded by ADR-NNNN | Deprecated
+**Date:** YYYY-MM-DD
+**Deciders:** @user1, @user2
+
+## Context
+
+What forces are at play. What we tried. What we observed.
+
+## Decision
+
+The decision, in one paragraph. Use module/interface/seam/etc. where it sharpens the claim.
+
+## Consequences
+
+- Positive: leverage / locality gained.
+- Negative: complexity introduced, work pushed elsewhere.
+- Open: what remains undecided, what triggers revisiting.
+
+## Alternatives considered
+
+Short list, one-line reason each was rejected.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,74 @@
+# Architecture
+
+A map of the three top-level **modules** in the eli-hmi stack and the **seams** between them. Vocabulary follows the [improve-codebase-architecture skill](../.agents/skills/improve-codebase-architecture/LANGUAGE.md): *module, interface, implementation, seam, adapter, depth, leverage, locality.*
+
+## Modules
+
+```
+┌──────────────────────────┐      WebSocket /ws/pvs       ┌──────────────────────────┐
+│  frontend                │ ───────── subscribe ───────▶ │  one of:                 │
+│  Next.js 15 / React 19   │ ◀──────── pv frames ──────── │  • mock-backend (Go)     │
+│  App Router              │                              │  • python-backend (Py)   │
+│                          │                              │    + aioca + EPICS net   │
+│  POST /pv/<NAME>         │ ─────── single write ──────▶ │                          │
+└──────────────────────────┘      (auth header)           └──────────────────────────┘
+```
+
+### 1. `frontend/` — Next.js App Router
+
+The user-facing **module**. Its **interface** is composed of:
+
+- Routes under `src/app/(modules)/<name>/page.tsx`, each gated by a [zone](frontend/zones.md).
+- A single **WebSocket client adapter** (`useWebSocket` + `useWebSocketContext`) that consumes whichever backend `NEXT_PUBLIC_API_URL` resolves to (the same host:port serves WS and the write endpoint — see `frontend/src/types/constants.ts`). Callers go through `useWebSocketData` which buries the dev-prefix mapping (see [pv-naming](reference/pv-naming.md)).
+- A single **write adapter** — `fetch('POST /pv/<NAME>', { headers: { Authorization } })` — used by exactly two call sites (`WarningErrorControl.tsx`, `DropDownStateControl.tsx`).
+
+Depth claim: `useWebSocketData` is deep. Behind a 2-arity hook (`pv` or `{pvs:[]}`) sits: NextAuth JWT acquisition, reconnect with backoff + jitter, subscription replay, prefix resolution, typed message envelope. Deleting the hook would scatter that complexity across every PV consumer — the deletion test passes.
+
+[Frontend overview →](frontend/overview.md)
+
+### 2. `backend/mockup-websocket-server/` — Go simulator
+
+A development-only **adapter** for the WS protocol. Its **interface** is the wire protocol (subscribe/pv frames) plus a REST side-door for tests (`/pv/:name/:value`, `/mode/:prefix/:value`).
+
+Implementation: one goroutine per unique PV; value inference from PV-name prefix (`AI_*` float, `BI_*` bool, `SI_*` string); ticker broadcasts every ~400 ms unless the prefix is in manual mode.
+
+[Mock server →](backend/mock-server.md)
+
+### 3. `backend/python-websocket-server/` — FastAPI + aioca
+
+The production **adapter**. Its **interface** is a superset of the mock's: subscribe/pv frames *and* a richer dialect with `connection_id`, `subscription_id`, `snapshot`/`event` separation, ping/pong, and limits negotiation. Talks to a real EPICS network via [aioca](https://github.com/DiamondLightSource/aioca).
+
+Also exposes: `GET /pv/<name>` (typed read), `/health/live`, `/health/ready`, `/stats`, `/stats/ui`, and an HTML landing page at `/`.
+
+[Python server →](backend/python-server.md)
+
+## Seams
+
+Three **seams** carry all cross-module traffic. Two adapters exist for the WS seam → it is a real seam, not hypothetical.
+
+### Seam 1: WebSocket pub/sub (`/ws/pvs`)
+
+Where the frontend's WS client meets a backend adapter. JWT is passed as `?auth=<token>` query param — both backends require it.
+
+⚠ **Known divergence.** The mock and Python adapters do not currently satisfy the *same* interface. The mock speaks the legacy frame shape (`{type:'subscribe', pvs:{NAME:true}}` → `{type:'pv', name, value, …}`); the Python server speaks a richer dialect (`subscription_id`, separate `snapshot`/`event` frames). The frontend client currently emits the legacy shape. This is the load-bearing question for [ADR-0009](adr/0009-shared-ws-protocol-contract.md) and detailed in [websocket-protocol](backend/websocket-protocol.md).
+
+### Seam 2: PV write endpoint (`POST /pv/<NAME>`)
+
+Single write adapter at a single seam. See [pv-write-endpoint](backend/pv-write-endpoint.md) and [ADR-0004](adr/0004-single-pv-write-endpoint.md).
+
+### Seam 3: Auth (NextAuth + LDAP)
+
+Server-side LDAP bind on credentials login (or dev bypass `test/test`); the NextAuth JWT is then carried (a) inside the browser session, (b) on the WS subscribe URL, (c) on PV-write requests. See [frontend/auth](frontend/auth.md).
+
+## Module-internal seams (frontend)
+
+Three patterns recur inside the frontend and earn their own pages:
+
+- **Zone config** (`src/lib/settings/zone-config.ts` + `src/middleware.ts`) — build-time access control. The middleware is the adapter; the zone descriptor is the interface. See [frontend/zones](frontend/zones.md).
+- **ModuleConfig** (`src/lib/modules/types.ts` + per-module config files) — deep declarative shape that drives `<ModuleControlPage>`. Used by three pages today; the pattern is a real seam. See [frontend/module-pages](frontend/module-pages.md). L4 OPCPA opts out — see [ADR-0007](adr/0007-l4-custom-shell-not-modulecontrolpage.md).
+- **Compound HMI components** (`components/hmi/{volume-panel,connector-line,laser-panel,controls}`) — parent attaches subcomponents as static properties so pages compose declaratively. See [frontend/hmi-components](frontend/hmi-components.md) and [ADR-0003](adr/0003-compound-components-for-hmi-panels.md).
+
+## Cross-cutting concerns
+
+- **PV naming.** Logical PV names in code (`MOD1.AI_TEMP`) are resolved to prefixed wire names (`DEV:MOD1:AI_TEMP`) by `getPrefixedPV` (`src/lib/utils/pv-helpers.ts`). The hook does this on subscribe; one write site does it inline. See [reference/pv-naming](reference/pv-naming.md).
+- **L4 OPCPA PV registry.** The laser-control page maintains a dedicated PV-name registry rather than scattering string literals. See [ADR-0006](adr/0006-pv-name-registry-l4-opcpa.md) and [frontend/l4-opcpa](frontend/l4-opcpa.md).

--- a/docs/backend/mock-server.md
+++ b/docs/backend/mock-server.md
@@ -1,0 +1,82 @@
+# Mock server (Go)
+
+`backend/mockup-websocket-server/`. Echo + Gorilla. One binary, no storage, no external deps. Use for local dev and frontend integration tests.
+
+## What it is
+
+A simulator. Each unique PV mentioned by any client spawns one `pvSim` goroutine that owns the value and a subscriber set. A ticker (~300–400 ms) broadcasts the current value to subscribers and, unless the prefix is in manual-only mode, drifts the value. When the last subscriber for a PV disconnects, the simulator shuts down.
+
+The value type is inferred from the **PV-name prefix**:
+
+| Prefix | Value type | Notes |
+| --- | --- | --- |
+| `AI_*` | `float64` | Auto-drift in normal mode |
+| `BI_*` | `bool` | Default mode is *manual* (`biMode=2`) — bool drift would be noise |
+| `SI_*` | `string` | Default mode is *manual* (`siMode=2`); cycles through preset words |
+| `CMD_*` | (command) | L4 OPCPA additions — see below |
+
+These are mock-only conventions; the real EPICS network does not use them. See [pv-naming](../reference/pv-naming.md).
+
+## Endpoints
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/ws/pvs?auth=<jwt>` | WebSocket subscribe / unsubscribe / set |
+| `POST` | `/pv/:name` | **Primary write endpoint** (L4 OPCPA). Body: `{"value": ...}`. Auth header required. |
+| `PUT` | `/pv/:name` | Realistic write contract used by frontend `WarningErrorControl` / `DropDownStateControl`. |
+| `GET` | `/pv/:name/:value` | REST side-door — set any PV from a URL (developer convenience). |
+| `GET` | `/mode/:prefix/:value` | Toggle a prefix between auto-simulate (`1`) and manual (`2`). |
+| `GET` | `/mode/fail-rate/:n` | L4 OPCPA: percentage of writes that should fail. `0` disables. Default 10. |
+| `GET` | `/waveforms` | L4 OPCPA: list available waveform names for `WaveformSelect`. |
+
+## WS frame contract
+
+```jsonc
+// client → server
+{ "type": "subscribe",   "pvs": { "AI_TEMP": true } }
+{ "type": "unsubscribe", "pvs": { "BI_DOOR": true } }
+{ "type": "set",         "pvs": { "BI_DOOR": true, "AI_MOTOR_POS_X": 42.5 } }
+
+// server → client (one frame per PV)
+{ "type": "pv", "name": "AI_TEMP", "value": 42.5,
+  "severity": 0, "ok": true, "timestamp": 1746000001.7, "units": "°C",
+  "error": "" }
+```
+
+Detail and rationale in [websocket-protocol](websocket-protocol.md).
+
+## L4 OPCPA extensions
+
+The mock hand-mirrors the [L4 OPCPA PV-name registry](../../frontend/src/app/(modules)/l4-opcpa/lib/pv-names.ts) in `l4_opcpa.go`. A header comment in that file points back to `pv-names.ts` as the canonical source. **Keep them in sync.** See [ADR-0006](../adr/0006-pv-name-registry-l4-opcpa.md).
+
+Effect chains: command PVs (`CMD_<L>_<NAME>`) trigger coordinated writes across 25+ effect PVs. The simulator holds each effect's value for 3 s before releasing it back to drift.
+
+10 % failure injection on writes is **off by default**. Enable for demos:
+
+```bash
+curl http://localhost:8080/mode/fail-rate/10
+```
+
+## Tuning constants
+
+Top of `main.go`:
+
+```go
+var (
+    aiMode = 1            // 1 = autosimulate, 2 = manual
+    biMode = 2
+    siMode = 2
+    updatePeriodMs = 300
+    randomWords = []string{ "High Vacuum Pumping", "High Vacuum", ... }
+)
+```
+
+Edit + `go run main.go` to see the effect.
+
+## Running
+
+See [running-mock-backend](../runbooks/running-mock-backend.md).
+
+## Source-of-truth README
+
+[`backend/mockup-websocket-server/readme.md`](../../backend/mockup-websocket-server/readme.md).

--- a/docs/backend/overview.md
+++ b/docs/backend/overview.md
@@ -1,0 +1,42 @@
+# Backend overview
+
+Two backend **modules**, one nominal **interface** (the WebSocket pub/sub pattern at `/ws/pvs`). The frontend doesn't know which is on the other end.
+
+## The two adapters
+
+| Module | Path | Language | Role | Port |
+| --- | --- | --- | --- | --- |
+| Mock | `backend/mockup-websocket-server/` | Go (Echo + Gorilla) | Dev/test — synthesises PV values from name prefixes | 8080 |
+| Python | `backend/python-websocket-server/` | Python (FastAPI + aioca) | Production — proxies a real EPICS network | (configurable) |
+
+Two adapters on the same nominal seam → this is a **real seam**, not hypothetical. Each adapter has its own page:
+
+- [Mock server (Go)](mock-server.md)
+- [Python server (FastAPI + aioca)](python-server.md)
+
+## What's actually shared
+
+| Capability | Mock | Python |
+| --- | --- | --- |
+| `GET /ws/pvs` accepts `?auth=<jwt>` | ✓ | ✓ |
+| Reads (subscribe → push) | ✓ | ✓ (richer dialect) |
+| Writes via `POST /pv/<NAME>` | ✓ | ✗ (read/monitor only — see [its README](../../backend/python-websocket-server/README.md)) |
+| Synthetic value drift | ✓ | n/a (real PVs) |
+| REST-side helpers (`/pv/:n/:v`, `/mode/:p/:v`) | ✓ | n/a |
+| Health / stats endpoints | ✗ | ✓ (`/health/{live,ready}`, `/stats`, `/stats/ui`) |
+
+The two big gaps — wire-frame divergence and write-side asymmetry — are documented in [websocket-protocol](websocket-protocol.md), [pv-write-endpoint](pv-write-endpoint.md), and [ADR-0009](../adr/0009-shared-ws-protocol-contract.md).
+
+## Mock-vs-Python split — why both exist
+
+Recorded in [ADR-0005](../adr/0005-mock-vs-python-backend-split.md). Short version: the mock decouples frontend development from EPICS availability, and the prefix-based synthesis (`AI_*` float / `BI_*` bool / `SI_*` string) gives every page deterministic, type-correct test data without an EPICS database. The Python server is the production endpoint that talks to actual hardware.
+
+## Running them
+
+- [Running the mock backend](../runbooks/running-mock-backend.md)
+- [Running the Python backend](../runbooks/running-python-backend.md)
+- [Deploying the Python backend](../runbooks/deploying-python-backend.md)
+
+## Auth on the wire
+
+Both backends require `?auth=<jwt>` on the WS upgrade. The token is a NextAuth JWT — see [auth](../frontend/auth.md).

--- a/docs/backend/pv-write-endpoint.md
+++ b/docs/backend/pv-write-endpoint.md
@@ -1,0 +1,56 @@
+# PV write endpoint
+
+A single HTTP endpoint that writes one PV. The contract:
+
+```http
+POST /pv/<NAME>
+Authorization: Bearer <jwt>
+Content-Type: application/json
+
+{ "value": <typed value> }
+```
+
+Response: 200 with `{ "ok": true }` on success; 4xx/5xx with `{ "ok": false, "error": "..." }` on failure.
+
+## Why one endpoint, not many
+
+See [ADR-0004](../adr/0004-single-pv-write-endpoint.md). Two relevant properties:
+
+- **Locality.** Every UI action that mutates state — a button, a dropdown, a chip preset, a CMD trigger — goes through the same endpoint and the same client-side hook (`usePvWrite` / `pvWrite()`). Audit, retry, logging, auth, and error UX live in one place.
+- **Leverage.** New control panels don't grow new endpoints. Adding a button on the frontend equals adding a row in the mock's `l4_opcpa.go` value table. Two integrations, no API surface change.
+
+## Adapters
+
+| Backend | Honors `POST /pv/<NAME>`? |
+| --- | --- |
+| Mock | ✓ (`writePvHandler` in `main.go`) |
+| Python | ✗ (read/monitor only today — see [its README](../../backend/python-websocket-server/README.md)) |
+
+The mock is the only adapter that implements the write seam. The Python server has not yet grown a write path — when it does, it must honor this contract (or [ADR-0004](../adr/0004-single-pv-write-endpoint.md) must be revisited).
+
+## Command PVs
+
+Some writes hide effect chains. On the mock, writing to `CMD_<L>_<NAME>` triggers 25+ downstream PV writes (e.g. `CMD_NL2_START_LASER`). The frontend treats CMD PVs as fire-and-forget triggers — same write contract, server-side dispatch. See [l4-opcpa](../frontend/l4-opcpa.md#write-path).
+
+## Failure injection (mock)
+
+```bash
+curl http://localhost:8080/mode/fail-rate/10   # 10 % of writes fail
+curl http://localhost:8080/mode/fail-rate/0    # disable
+```
+
+Default rate is 0. The L4 demo workflow flips it to 10 % to exercise frontend error UI.
+
+## Frontend call sites
+
+| Path | Caller |
+| --- | --- |
+| `src/lib/api/pvs.ts` → `pvWrite()` | The single write adapter. Every control consumes `usePvWrite()` which calls `pvWrite()`. |
+| `src/components/hmi/volume-panel/components/WarningErrorControl.tsx` | Direct `fetch()` + `getPrefixedPV()` — predates `pvWrite()`. |
+| `src/components/hmi/volume-panel/components/internal/DropDownStateControl.tsx` | Same as above. |
+
+The two direct call sites should migrate to `pvWrite()` so that `getPrefixedPV` has zero write-side call sites — see the [context](../context.md#what-good-deepening-looks-like-here) for why.
+
+## Auth
+
+The `Authorization: Bearer <jwt>` header is required. The token is the same NextAuth JWT used on the WebSocket — see [auth](../frontend/auth.md).

--- a/docs/backend/python-server.md
+++ b/docs/backend/python-server.md
@@ -1,0 +1,116 @@
+# Python server (FastAPI + aioca)
+
+`backend/python-websocket-server/`. Production target. Talks to a real EPICS network via [aioca](https://github.com/DiamondLightSource/aioca). **Read/monitor only** at present — no write endpoint yet.
+
+## What it is
+
+A FastAPI app whose **interface** is HTTP + WebSocket. The implementation is built around a `WebSocketPVsManager` that owns:
+
+- a shared-monitor pool (one aioca `camonitor` per unique PV regardless of subscriber count)
+- per-connection subscription bookkeeping
+- limits (`max_pvs_per_subscription`, `max_subscriptions_per_connection`)
+- stats snapshots
+
+## Module layout (`backend/python-websocket-server/`)
+
+| File | Role |
+| --- | --- |
+| `server.py` | FastAPI app — routes, lifespan, error handlers |
+| `app_settings.py` | `AppSettings.from_env()` — environment binding |
+| `aioca_api.py` | Thin adapter over aioca (read once, type resolution) |
+| `api_contract.py` | Pydantic models — `DetailLevel`, `DatatypeAlias`, `ReadRequestOptions`, `StatsResponse`, `validate_pv_name` |
+| `pv_serialization.py` | `build_pv_response`, `generic_error_payload` — uniform envelope across REST + WS |
+| `websocket_pv_manager.py` | Heart of the module: connection + subscription + monitor management |
+| `root_docs_page.py` + `root_docs.md` | HTML landing page rendered at `GET /` |
+| `stats_dashboard.py` | HTML dashboard at `/stats/ui` (live snapshot of `/stats`) |
+| `logging_utils.py` | `configure_logging(level, json)` |
+| `tests/` | pytest |
+
+## Endpoints
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/` | HTML landing page with quick links |
+| `GET` | `/docs`, `/redoc` | OpenAPI (toggled by `ENABLE_DOCS`) |
+| `GET` | `/pv/{pv_name}` | Typed read. Query params: `detail`, `datatype`, `count`, `timeout`. |
+| `GET` | `/ws/pvs?auth=<jwt>` | WebSocket — connect, subscribe, snapshot, event, unsubscribe, ping/pong |
+| `GET` | `/health/live`, `/health/ready` | Liveness / readiness |
+| `GET` | `/stats` | JSON snapshot — connections, monitors, subscribers, cached values |
+| `GET` | `/stats/ui` | HTML dashboard auto-refreshing from `/stats` |
+
+## WebSocket dialect (richer than the mock)
+
+The Python server's WS interface is a strict superset of the mock's surface — but uses a different frame contract:
+
+```jsonc
+// server → client on connect
+{ "type": "connected", "operation": "monitor",
+  "connection_id": "abc123def456",
+  "limits": { "max_pvs_per_subscription": 64,
+              "max_subscriptions_per_connection": 32 } }
+
+// client → server
+{ "type": "subscribe", "subscription_id": "main",
+  "pvs": ["DEVICE:PV1", "DEVICE:PV2"],
+  "detail": "time", "timeout": 2.0,
+  "all_updates": false, "notify_disconnect": true }
+
+// server → client (after subscribe)
+{ "type": "subscribed", "operation": "monitor",
+  "subscription_id": "main", "detail": "time",
+  "pvs": ["DEVICE:PV1", "DEVICE:PV2"], "ok": true }
+
+{ "type": "snapshot", "operation": "monitor",
+  "subscription_id": "main", "pv": "DEVICE:PV1",
+  "detail": "time", "ok": true, "value": 42.5, "metadata": {} }
+
+{ "type": "event", ... }   // live updates
+
+{ "type": "unsubscribe", "subscription_id": "main" }
+{ "type": "ping", "nonce": "123" }
+```
+
+The mock backend speaks a simpler frame shape (`pvs` as object, single `pv` frame type). The frontend client currently emits the mock dialect — see [websocket-protocol](websocket-protocol.md) and [ADR-0009](../adr/0009-shared-ws-protocol-contract.md) for the gap.
+
+## Read endpoint
+
+```bash
+curl "http://localhost:8080/pv/DEVICE:PV?detail=control&timeout=2.5"
+```
+
+`detail`: `value` | `time` | `control`
+`datatype`: `native` | `string` | `integer` | `float` | `enum_string` | `char_string` | `char_bytes` | `char_unicode` | `class_name` | `stsack_string`
+`count`: `0` (single), `-1` (waveform), or positive integer
+`timeout`: bounded by server config
+
+## Health & stats
+
+`/stats` returns server readiness, active WS count, shared monitor count, subscription totals, per-connection PV lists, per-monitor subscriber lists, cached last values. `/stats/ui` is the dashboard.
+
+## Configuration
+
+| Env var | Default | Notes |
+| --- | --- | --- |
+| `HOST` | `0.0.0.0` | |
+| `PORT` | (per Makefile) | |
+| `LOG_LEVEL` | `INFO` | |
+| `LOG_JSON` | `false` | |
+| `DEFAULT_TIMEOUT` | 2.0 s | aioca read default |
+| `MAX_TIMEOUT` | 30 s | upper bound on per-request timeout |
+| `MAX_PVS_PER_SUBSCRIPTION` | 64 | |
+| `MAX_SUBSCRIPTIONS_PER_CONNECTION` | 32 | |
+| `ENABLE_DOCS` | true | gates `/docs` and `/redoc` |
+
+See [reference/env-vars](../reference/env-vars.md) for the consolidated table.
+
+## What's not here yet
+
+- **No write endpoint.** Writes are out of scope for the current Python server. The mock's `POST /pv/<NAME>` has no counterpart. Cross-reference: [pv-write-endpoint](pv-write-endpoint.md), [ADR-0004](../adr/0004-single-pv-write-endpoint.md).
+
+## Running
+
+See [running-python-backend](../runbooks/running-python-backend.md) and [deploying-python-backend](../runbooks/deploying-python-backend.md).
+
+## Source-of-truth README
+
+[`backend/python-websocket-server/README.md`](../../backend/python-websocket-server/README.md).

--- a/docs/backend/websocket-protocol.md
+++ b/docs/backend/websocket-protocol.md
@@ -1,0 +1,114 @@
+# WebSocket protocol
+
+The nominal **interface** at the `/ws/pvs` **seam**. Two backend adapters claim to satisfy it. They don't — yet. This page documents what each one actually emits and what the frontend actually sends.
+
+> ⚠ This is the load-bearing question for [ADR-0009](../adr/0009-shared-ws-protocol-contract.md). The ADR is still **Open** — there is no accepted contract that both sides have implemented.
+
+## Common ground
+
+| Aspect | Both backends |
+| --- | --- |
+| URL path | `/ws/pvs` |
+| Auth | `?auth=<jwt>` query parameter on upgrade |
+| Subprotocol | none |
+| Frame format | JSON text frames |
+| One frame | one PV update |
+
+## What the frontend sends today
+
+`src/lib/websocket/use-websocket.ts`:
+
+```jsonc
+{ "type": "subscribe",   "pvs": { "<PV_NAME>": true } }   // one or many keys
+{ "type": "unsubscribe", "pvs": { "<PV_NAME>": true } }
+```
+
+PVs are passed as an *object* keyed by name. There is no `subscription_id`, no `detail`, no `timeout`. The client opens one connection per browser tab; subscriptions are deduplicated locally and replayed on reconnect.
+
+## Mock backend dialect (Go)
+
+Matches the frontend exactly.
+
+```jsonc
+// client → server
+{ "type": "subscribe", "pvs": { "AI_TEMP": true } }
+
+// server → client (per-PV broadcast, every updatePeriodMs)
+{ "type": "pv",
+  "name": "AI_TEMP",
+  "value": 42.5,
+  "severity": 0,
+  "ok": true,
+  "timestamp": 1746000001.7,
+  "units": "°C",
+  "error": "" }
+```
+
+Frames:
+
+| `type` | Direction | Notes |
+| --- | --- | --- |
+| `subscribe` | →  | object-keyed PVs |
+| `unsubscribe` | →  | object-keyed PVs |
+| `set` | →  | mock-only, sets a value as if `caput` |
+| `pv` | ← | single frame type for everything |
+
+## Python backend dialect
+
+Richer surface. Different frame contract.
+
+```jsonc
+// server → client on open
+{ "type": "connected", "operation": "monitor",
+  "connection_id": "abc123def456",
+  "limits": { "max_pvs_per_subscription": 64,
+              "max_subscriptions_per_connection": 32 } }
+
+// client → server
+{ "type": "subscribe", "subscription_id": "main",
+  "pvs": ["DEVICE:PV1", "DEVICE:PV2"],
+  "detail": "time", "timeout": 2.0,
+  "all_updates": false, "notify_disconnect": true }
+```
+
+Frames:
+
+| `type` | Direction | Notes |
+| --- | --- | --- |
+| `connected` | ← | first frame on every connection; carries `connection_id` and limits |
+| `subscribe` | →  | `pvs` is an **array**; client picks the `subscription_id` |
+| `subscribed` | ← | ack |
+| `snapshot` | ← | initial value per PV after subscribe |
+| `event` | ← | subsequent updates |
+| `unsubscribe` | →  | by `subscription_id` |
+| `unsubscribed` | ← | ack |
+| `ping` / `pong` | → / ← | keepalive |
+| `error` | ← | structured error envelope |
+
+## The gap
+
+| | Mock | Python | Frontend |
+| --- | --- | --- | --- |
+| `pvs` shape | object | **array** | object |
+| `subscription_id` | absent | required | absent |
+| Initial value frame | normal `pv` | dedicated `snapshot` | handled as `pv` |
+| Updates | `pv` | `event` | handled as `pv` |
+| Connection ack | none | `connected` | ignored |
+| Per-frame `name`, `value`, `severity`, `units`, `timestamp`, `ok` | yes | yes (via `pv_serialization`) | yes |
+
+The frontend will not deserialise the Python server's frames as written. The Python server will not parse the frontend's `pvs:{...}` subscribe payload as written.
+
+## What this means in practice
+
+- `NEXT_PUBLIC_API_URL=localhost:8080` → `ws://localhost:8080/ws/pvs` (mock) — works.
+- `NEXT_PUBLIC_API_URL=<python-host>:<port>` → `ws://<python-host>:<port>/ws/pvs` — does **not** work without changes on either side.
+
+## How to resolve
+
+Three options, ordered by decreasing locality:
+
+1. **Adopt the Python dialect on the frontend** (and emulate it in the mock). Highest leverage long-term; biggest one-time change.
+2. **Add a compatibility shim to the Python server** for the legacy frame shape. Easiest to land; pushes complexity to the wrong side (the server learns dialects of clients).
+3. **Define a third, deliberate contract** and migrate both adapters to it. Best vocabulary; most coordination.
+
+See [ADR-0009](../adr/0009-shared-ws-protocol-contract.md). This page tracks the gap; the ADR decides the direction.

--- a/docs/context.md
+++ b/docs/context.md
@@ -1,0 +1,58 @@
+# Context
+
+This file gives the [improve-codebase-architecture skill](../.agents/skills/improve-codebase-architecture/SKILL.md) the domain language it needs to reason about deepening opportunities in this repo without re-discovering the domain.
+
+If you sharpen a term during a grilling conversation, edit it here.
+
+## What the system does
+
+**eli-hmi** is the Human-Machine Interface for ELI Beamlines laser-control rooms. Operators read live values, switch states, and drive command sequences on lab hardware. Hardware speaks EPICS; this stack proxies EPICS through a WebSocket to a browser HMI.
+
+Two backends, one frontend. The frontend is environment-agnostic: `NEXT_PUBLIC_API_URL` (e.g. `localhost:8080`) is the single host:port used to derive both `ws://<host>/ws/pvs` and `http://<host>/pv` (`frontend/src/types/constants.ts`).
+
+## Modules (top-level)
+
+- **frontend** — Next.js 15 App Router. Renders routes selected by a build-time zone.
+- **mock-backend** — Go service. Fakes PVs from name-prefix conventions. Dev/test only.
+- **python-backend** — FastAPI + aioca. Production adapter onto a real EPICS network.
+
+## Core domain concepts
+
+(Architecture vocabulary lives in [glossary](glossary.md). This section lists the *domain* names a future architecture review should use.)
+
+- **PV** — process variable. Atomic read/write unit. Name + value + severity + units + timestamp.
+- **Zone** — build-time deployment profile. Determines which routes a particular operator station can reach.
+- **Module page** — a control page driven by a `ModuleConfig` declarative descriptor (`l3bt-controls`, `l4fbt-controls`, `p3-controls`). One renderer (`ModuleControlPage`), three configs.
+- **L4 OPCPA** — exception to the module-page pattern. Has its own custom shell and a PV-name registry.
+- **HMI panel** — a reusable compound component (`VolumePanel`, `ConnectorLine`, `LaserPanel`) that engineers compose into pages.
+- **PV write** — a single `POST /pv/<NAME>` endpoint that both backends honour and that two frontend call sites use.
+
+## Decisions that should not be re-litigated
+
+Recorded as ADRs in [`/docs/adr/`](adr/):
+
+- WS pub/sub pattern (single connection, channel registry, replay on reconnect)
+- Zone-based access control (build-time, no runtime switch)
+- Compound components for HMI panels
+- Single PV write endpoint
+- Mock vs Python backend split
+- L4 OPCPA's PV-name registry
+- L4 OPCPA's custom shell (deliberate opt-out from `ModuleControlPage`)
+- Laser specs location
+
+The open architectural question — explicitly *not yet* an accepted ADR — is whether the mock and Python WS adapters should converge on one shared protocol contract. See [ADR-0009](adr/0009-shared-ws-protocol-contract.md).
+
+## What good deepening looks like here
+
+Deepening candidates worth surfacing should typically:
+
+- Concentrate currently-scattered PV-name string literals behind a named registry (the L4 OPCPA pv-names module is the model).
+- Push a configurable, per-page pattern into a deep declarative descriptor like `ModuleConfig` (with the L4 opt-out as the cautionary example of when *not* to).
+- Reduce the number of direct `getPrefixedPV` call sites at write time (currently 2, ideally 0 after lifting writes through a hook the way reads are).
+- Surface, rather than hide, the mock-vs-Python WS protocol divergence so the team can converge them deliberately.
+
+## What is *not* a deepening opportunity here
+
+- Translating Confluence product specs into source files. Confluence stays canonical for product/spec.
+- Generating TS-type docs (TypeDoc et al.). The team prefers hand-written prose.
+- Renaming HMI subcomponents to satisfy uniform-case rules across all directories — [the policy already permits PascalCase for single-component files](../frontend/AGENTS.md) (per commit `e9965be`).

--- a/docs/frontend/auth.md
+++ b/docs/frontend/auth.md
@@ -1,0 +1,43 @@
+# Auth
+
+NextAuth Credentials provider → server-side LDAP bind → JWT. The JWT is the access token carried on every cross-module hop.
+
+## Flow
+
+1. Operator submits username + password to the NextAuth credentials route.
+2. `src/lib/server/auth/ldap-auth.ts` does the LDAP bind:
+   - Production: `LDAP_SERVER_URL` (e.g. `ldap://10.78.0.11`), `LDAP_BASE_DN=dc=lcs,dc=local`.
+   - Dev bypass: `test` / `test` — same file, short-circuits to a fake user when both fields are exactly `test`.
+3. On success, NextAuth issues a JWT. `session.accessToken` is the token the rest of the app uses.
+
+## Three places the token travels
+
+| Carrier | Mechanism | Code |
+| --- | --- | --- |
+| Browser → frontend SSR | NextAuth session cookie | NextAuth managed |
+| Frontend → WS backend | `?auth=<token>` query parameter on the `/ws/pvs` URL | `useWebSocket` (`src/lib/websocket/use-websocket.ts`) |
+| Frontend → PV-write backend | `Authorization: Bearer <token>` header on `POST /pv/<NAME>` | `pvWrite()` (`src/lib/api/pvs.ts`) |
+
+Both backends verify the token.
+
+## Required env
+
+```
+NEXTAUTH_SECRET=<strong random>
+LDAP_SERVER_URL=ldap://10.78.0.11
+LDAP_BASE_DN=dc=lcs,dc=local
+# Optional
+LDAP_USE_TLS=true
+```
+
+See [reference/env-vars](../reference/env-vars.md) for the full list.
+
+## Dev login
+
+Username `test`, password `test`. The bypass is in `ldap-auth.ts` and is gated by the literal-string match — it doesn't depend on `NODE_ENV`, so don't ship a build that has the bypass active by mistake. See [`frontend/src/lib/server/auth/README.md`](../../frontend/src/lib/server/auth/README.md) for the production wiring.
+
+## Why the query param (not a header) for WebSocket
+
+Browsers cannot attach `Authorization` headers to a `WebSocket` upgrade request. The token is sent as `?auth=<token>` on the URL and validated server-side. Connection state is fully authenticated for the lifetime of the socket — there is no per-frame auth.
+
+This decision lives in [ADR-0001](../adr/0001-ws-pubsub-pattern.md).

--- a/docs/frontend/hmi-components.md
+++ b/docs/frontend/hmi-components.md
@@ -1,0 +1,31 @@
+# HMI components
+
+Reusable compound components under `frontend/src/components/hmi/`. The compound-component pattern is intentional: a parent attaches subcomponents as static properties (`VolumePanel.SensorBar`, `LaserPanel.Regen`) so engineers compose pages **declaratively** without managing React state. See [ADR-0003](../adr/0003-compound-components-for-hmi-panels.md).
+
+## Inventory
+
+| Component | Subcomponents | Domain | Canonical README |
+| --- | --- | --- | --- |
+| `VolumePanel` | `.SensorBar` `.Pump` `.TurbopumpBasic` `.Locking` `.Doors` `.Config` `.MasterKey` `.Interlocks` `.MultiVolumes` `.Container` `.WarningErrorControl` | Vacuum systems | [README](../../frontend/src/components/hmi/volume-panel/README.md) |
+| `ConnectorLine` | `.Line` `.Valve` `.Gate` `.GateConnected` `.LabelValue` `.ValveStatus` `.ValveControlStatus` | Vacuum systems | [README](../../frontend/src/components/hmi/connector-line/README.md) |
+| `LaserPanel` | `.General` `.Regen` `.Chillers` `.Flashlamps` `.Modbox` | Laser control (L4 OPCPA) | [README](../../frontend/src/components/hmi/laser-panel/README.md) |
+| `controls/` | `SectionCard` `DataRow` `DetailList` `usePvWrite` `ActionButton` `PresetIntegerInput` `CogToggle` `Values.{Float,Integer,String,BoolPill}` `WaveformSelect` | Reusable primitives (write controls + readouts) | [README](../../frontend/src/components/hmi/controls/README.md) |
+| `status-bar/` | (kebab-case directory; uniform-case carve-out applies — see [AGENTS](../../frontend/AGENTS.md)) | Connection status banner | — |
+
+## When to use which
+
+- **Vacuum/pump page** → start from `<VolumePanel>` + `<ConnectorLine>`, drive top panels from a `ModuleConfig` ([module pages](module-pages.md)).
+- **Laser control page** → `<LaserPanel>` + the `controls/` primitives. The L4 OPCPA page is the only consumer today; see [l4-opcpa](l4-opcpa.md).
+- **New control surface** that fits neither (e.g. cryogenics) → consider whether you have **two real adapters** before introducing a new compound family. *One adapter means a hypothetical seam; two adapters means a real one.*
+
+## Two flavours of readout
+
+`VolumePanel` readouts go through `PVDisplay` (icon + message on error). `LaserPanel` + `controls/Values` use a minimal `<>` glyph instead — the L4 wireframe specifies tight grid layouts where a full error UI would break the rhythm. Connection-lost feedback is centralised in a banner on the L4 page. See [laser-panel/README.md](../../frontend/src/components/hmi/laser-panel/README.md#readouts-valuestsx).
+
+## Write controls
+
+All write controls (`ActionButton`, `PresetIntegerInput`, `WaveformSelect`) share one lifecycle via `usePvWrite()` (`components/hmi/controls/usePvWrite.ts`) — idle/pending/success/error plus `CogToggle` auto-close on success. The hook is the deep module behind the buttons. See [controls/README.md](../../frontend/src/components/hmi/controls/README.md#write-controls).
+
+## Filename casing
+
+PascalCase for files whose export is a single React component (`VolumePanel.tsx`, `ActionButton.tsx`) is permitted in the `components/hmi/{controls,laser-panel,volume-panel,connector-line}/` subtrees. `status-bar/` uses kebab-case. **Don't mix within a directory.** See [AGENTS](../../frontend/AGENTS.md) and commit `e9965be`.

--- a/docs/frontend/l4-opcpa.md
+++ b/docs/frontend/l4-opcpa.md
@@ -1,0 +1,65 @@
+# L4 OPCPA
+
+The laser-control page. Lives at `frontend/src/app/(modules)/l4-opcpa/`. Source spec: [Confluence — Requirements: L4 OPCPA Control System](https://eli-eric.atlassian.net/wiki/spaces/CS/pages/2333902150).
+
+## Why this page is special
+
+Three things distinguish it from the other module pages:
+
+1. **Custom shell, not `ModuleControlPage`.** The L4 wireframe is a flat 5-column grid of laser status panels — General / Regen / Chillers / Flashlamps / Modbox. The vacuum-system layout of `ModuleControlPage` doesn't fit; forcing it would mean stubbing out every panel. See [ADR-0007](../adr/0007-l4-custom-shell-not-modulecontrolpage.md).
+2. **Per-page topology config, not `ModuleConfig`.** `laser-specs.ts` lives under this module's `components/`, not under `lib/modules/`. It describes per-laser *topology* (counts, IDs, presets) rather than the panel-layout `ModuleConfig` consumed by `ModuleControlPage`. See [ADR-0008](../adr/0008-laser-specs-location.md).
+3. **PV-name registry.** A dedicated module (`l4-opcpa/lib/pv-names.ts`) builds every PV name from typed helpers — no inline string templates anywhere in the laser code. See [ADR-0006](../adr/0006-pv-name-registry-l4-opcpa.md).
+
+## Layout
+
+```
+app/(modules)/l4-opcpa/
+├── page.tsx                       # custom shell
+├── page.module.css
+├── lib/
+│   ├── pv-names.ts                # PV-name registry
+│   └── pv-names.test.ts
+└── components/
+    ├── laser-grid.tsx             # CSS grid wrapper
+    ├── color-legend.tsx
+    ├── laser-specs.ts             # LASER_SPECS array
+    └── laser-panel-instance.tsx   # renders one laser from a LaserSpec
+```
+
+`LaserPanel` and its sections live in `frontend/src/components/hmi/laser-panel/` (shared compound component, not L4-specific). Reusable primitives (`SectionCard`, `DataRow`, `DetailList`, `usePvWrite`, `ActionButton`, `PresetIntegerInput`, `CogToggle`, `WaveformSelect`, readouts) live in `frontend/src/components/hmi/controls/`.
+
+## PV-name registry
+
+```ts
+import { pv } from '@/app/(modules)/l4-opcpa/lib/pv-names'
+
+pv.shutter('NL2')                       // 'BI_NL2_SHUTTER'
+pv.flashlampChannel('NL2', '22', '1')   // 'SI_NL2_FL_22_CH1'
+pv.cmd('NL2', 'START_LASER')            // 'CMD_NL2_START_LASER'
+pv.mssAll('NL2', 6)                     // ['BI_NL2_MSS_1', …, 'BI_NL2_MSS_6']
+```
+
+The mock backend (`backend/mockup-websocket-server/l4_opcpa.go`) hand-mirrors the same names. A header comment in `l4_opcpa.go` points back to `pv-names.ts` as the canonical source. **Keep them in sync** when adding PVs.
+
+## Write path
+
+Every UI action is `POST /pv/<NAME>` with `{value: ...}`:
+
+- **Command PVs** (`CMD_<L>_<NAME>`) — the backend dispatches a coordinated effect chain (e.g. `start_laser` writes 25+ PVs). The frontend treats the CMD PV as a fire-and-forget trigger.
+- **Direct PVs** (`BI_<L>_SHUTTER`, `AI_<L>_ATT`) — straight write.
+
+All controls share one lifecycle via `usePvWrite()` — see [hmi-components](hmi-components.md#write-controls).
+
+## Topology source
+
+`LASER_SPECS` mirrors NL2's topology across NL1, NL3, NL4, NL5 because Confluence only documents NL2 and APL. When divergent topology is confirmed (chiller bank counts, flashlamp box IDs per laser), extend `LASER_SPECS` per entry. The static config is a placeholder for the day a `GET /lasers` endpoint exists on the python-backend — at that point the fetch replaces the constant and topology becomes the canonical source. (Recorded in [ADR-0008](../adr/0008-laser-specs-location.md).)
+
+## Mock-backend behaviour
+
+The mock seeds at-rest defaults for all 5 lasers on startup. Sequences hold their effect-PV writes for 3 s before releasing them back to auto-simulated drift around the last-set value. 10 % failure injection is off by default — enable it for demos:
+
+```bash
+curl http://localhost:8080/mode/fail-rate/10
+```
+
+Detail: [`frontend/src/app/(modules)/l4-opcpa/README.md`](../../frontend/src/app/(modules)/l4-opcpa/README.md).

--- a/docs/frontend/module-pages.md
+++ b/docs/frontend/module-pages.md
@@ -1,0 +1,47 @@
+# Module pages
+
+The pattern that drives `/p3-controls`, `/l3bt-controls`, `/l4fbt-controls`. One renderer; per-module configs. [L4 OPCPA deliberately opts out](l4-opcpa.md).
+
+## Interface
+
+```tsx
+<ModuleControlPage config={myConfig} bottomRow={<MyBottomRow />} />
+```
+
+- `config: ModuleConfig` — typed declarative description of the five fixed panels (heading, interlocks, safety permission, clean-dry-air, backing, roughing).
+- `bottomRow: ReactNode` — bespoke JSX (volumes + connectors with site-specific PV wiring).
+
+`ModuleConfig` lives at `src/lib/modules/types.ts`. Per-module configs live alongside:
+
+```
+src/lib/modules/
+├── types.ts
+├── l3bt.config.ts
+├── l4fbt.config.ts
+└── p3.config.ts
+```
+
+## Why split this way
+
+The five top panels share a uniform shape — they vary only in *data* (PV names, titles, sensor counts), so a typed config captures all variance without ever touching JSX. The bottom row, by contrast, has *structural* variance: number of sub-volumes, mix of compound children, cross-module hyperlinks. Forcing it into the config would either explode the schema or push it back into JSX through a glob of conditionals. Keeping the bottom row as a slot is the boundary where declarative stops paying.
+
+This is `ModuleControlPage`'s **depth**: a small interface (`config + bottomRow`) ferries five fully-wired panels into the page.
+
+## Adding a module
+
+(Full recipe: [workflows/adding-a-control-page](../workflows/adding-a-control-page.md).)
+
+1. New `src/lib/modules/<m>.config.ts`.
+2. New `src/app/(modules)/<m>-controls/page.tsx` rendering `<ModuleControlPage>`.
+3. Per-module `parts/` for volumes + connectors.
+4. Register `/-controls` route + nav item in [zone config](zones.md).
+
+## PV naming inside configs
+
+Pass **logical** names. `useWebSocketData` applies the dev-prefix on subscribe. See [pv-naming](../reference/pv-naming.md).
+
+Several existing entries carry placeholder PV names — they are deliberate, not oversights. See [`frontend/src/lib/modules/README.md`](../../frontend/src/lib/modules/README.md#deliberate-placeholders).
+
+## Tests
+
+`src/components/module-page/**` is inside the coverage gate (70/70/70/60). Tests live next to the panels they exercise.

--- a/docs/frontend/overview.md
+++ b/docs/frontend/overview.md
@@ -1,0 +1,52 @@
+# Frontend overview
+
+Next.js 15 / React 19 / TypeScript under `frontend/`. App Router. Turbopack dev server on **port 8082** (not 3000).
+
+## What the frontend is
+
+A control-system HMI rendered in the browser, run from operator stations. The audience for *new pages* is control-system engineers — not React specialists. Pages are composed from a typed [ModuleConfig](module-pages.md) plus a small set of [compound HMI components](hmi-components.md). The frontend doesn't know which backend is on the other end of the WebSocket; see [architecture](../architecture.md).
+
+## Top-level **modules** inside `frontend/src/`
+
+| Path | Role |
+| --- | --- |
+| `app/` | Routes (App Router), providers, layouts, `middleware.ts`. |
+| `app/(modules)/<m>-controls/` | One route per control module — usually a 5-line `<ModuleControlPage>` call. |
+| `app/(modules)/l4-opcpa/` | Exception: custom shell, custom PV registry. [Detail.](l4-opcpa.md) |
+| `app/providers/` | `WebSocketProvider`, session provider, theme. |
+| `components/hmi/` | Compound HMI components: `VolumePanel`, `ConnectorLine`, `LaserPanel`, `StatusBar`, `controls/`. [Detail.](hmi-components.md) |
+| `components/module-page/` | `<ModuleControlPage>` shell + 5 config-driven panels. |
+| `components/navigation/` `components/ui/` | Nav bar, generic primitives. |
+| `lib/websocket/` | WS client adapter — `useWebSocket`, `useWebSocketData`, `PVDisplay`, `WebSocketProvider`. [Detail.](websocket-client.md) |
+| `lib/settings/` | `zone-config.ts` + zone helpers. [Detail.](zones.md) |
+| `lib/modules/` | `ModuleConfig` types + per-module configs. [Detail.](module-pages.md) |
+| `lib/server/auth/` | NextAuth + LDAP. [Detail.](auth.md) |
+| `lib/utils/pv-helpers.ts` | `getPrefixedPV`, `getFormattedValue`. [Detail.](../reference/pv-naming.md) |
+| `lib/api/pvs.ts` | `pvWrite()` — the single PV-write adapter onto `POST /pv/<NAME>`. |
+| `test/` | Vitest setup + two WS test seams (`ws-mock-server.ts`, `ws-test-provider.tsx`). |
+| `middleware.ts` | Zone + auth gate. |
+
+## Conventions
+
+| Topic | Rule |
+| --- | --- |
+| Path alias | `@/` → `frontend/src/` |
+| Filenames | kebab-case for non-component modules; PascalCase permitted for files whose export is a single React component matching the filename. Don't mix within a directory. |
+| Style | Prettier: no semicolons, single quotes. |
+| Client components | Declare `'use client'`. |
+| CSS | CSS Modules with kebab-case class names; variants via `styles[\`name-${variant}\`]`. |
+| Theme | Use tokens from `src/app/globals.css` (`--color-*`, `--shadow-*`, `--border-radius-*`). |
+| Commit subjects | Short imperative; prefix Jira/issue id if present (`OPHMI-15: …`). |
+
+Detail: [`frontend/AGENTS.md`](../../frontend/AGENTS.md).
+
+## Test seams
+
+- `mockWebSocketServer()` (`src/test/ws-mock-server.ts`) — replaces `globalThis.WebSocket`. Use for connection-lifecycle and integration tests. Honours the on-wire frame contract.
+- `<TestWebSocketProvider value={fakeContext}>` (`src/test/ws-test-provider.tsx`) — short-circuits the connection layer for fast component tests.
+
+The split is itself an example of *adapter vs implementation*: same interface (`WebSocketContext`), two implementations, used as **adapters** at the test seam.
+
+## Coverage gate
+
+`.gitlab-ci.yml` `frontend-test` enforces 70/70/70/60 over `src/lib/websocket/**`, `src/lib/settings/**`, `src/middleware.ts`, `src/components/module-page/**` (the parts most expensive to break).

--- a/docs/frontend/websocket-client.md
+++ b/docs/frontend/websocket-client.md
@@ -1,0 +1,58 @@
+# Frontend WebSocket client
+
+The deep **module** that sits in front of every PV read in the app. One app-wide WS connection. Subscribers don't deal with the wire, reconnects, or prefix mapping.
+
+## Interface
+
+```ts
+useWebSocketData(pv: string)              // → { data,  isConnected }
+useWebSocketData({ pvs: string[] })       // → { byPv, state, isConnected }
+```
+
+The hook is the **interface**; callers pass *logical* PV names and get typed `Message<T>` envelopes back. Everything else is implementation detail.
+
+```tsx
+import { useWebSocketData } from '@/lib/websocket/use-websocket-data'
+import { PVDisplay } from '@/lib/websocket/pv-display'
+
+const Pressure = ({ pv }: { pv: string }) => {
+  const { data, isConnected } = useWebSocketData<number>(pv)
+  return <PVDisplay data={data} isConnected={isConnected} />
+}
+```
+
+## What the hook hides
+
+- **Connection lifecycle.** `useWebSocket` (`src/lib/websocket/use-websocket.ts`) owns the WebSocket. State is `connecting | connected | disconnected`.
+- **NextAuth JWT.** `session.accessToken` is passed as `?auth=<token>` on the URL — both backends require it.
+- **Reconnect.** Exponential backoff with jitter, capped at 30 s. `replaySubscriptions()` re-subscribes every channel on reopen.
+- **Subscription dedup.** One wire-level subscription per PV regardless of how many React components ask for it.
+- **PV-name prefix mapping.** `getPrefixedPV` is applied on subscribe *and* on lookup. Callers stay in logical names. See [pv-naming](../reference/pv-naming.md).
+- **Typed message envelope.** `Message<T>` carries `value`, `severity`, `units`, `timestamp`, `ok`. `isConnected` plumbed alongside.
+
+`PVDisplay` renders `Message<T>` with sensible loading / error / disconnected fallbacks (`formatValue`, `errorComponent`, `loadingComponent`, `onError`).
+
+## Why this is a deep module
+
+Apply the deletion test: take the hook away and each PV consumer has to acquire the session token, open a WebSocket, debounce reconnects, map prefixes, dedup subscriptions, parse frames, and reconcile state. That complexity reappears at every call site. The hook earns its keep — and is the right shape for the *interface = test surface* principle.
+
+The two test adapters described in [overview](overview.md#test-seams) sit at the same seam.
+
+## Wire frames (mock dialect)
+
+```jsonc
+// client → server
+{ "type": "subscribe", "pvs": { "AI_TEMP": true, "BI_DOOR": true } }
+{ "type": "unsubscribe", "pvs": { "BI_DOOR": true } }
+{ "type": "set", "pvs": { "BI_DOOR": true } }
+
+// server → client
+{ "type": "pv", "name": "AI_TEMP", "value": 42.5,
+  "severity": 0, "ok": true, "timestamp": 1746000001.7, "units": "°C" }
+```
+
+The Python backend speaks a richer dialect — see [websocket-protocol](../backend/websocket-protocol.md) and [ADR-0009](../adr/0009-shared-ws-protocol-contract.md).
+
+## Write side
+
+Reads go through the hook. **Writes do not** — they go through `pvWrite()` (`src/lib/api/pvs.ts`) onto `POST /pv/<NAME>`. Two direct call sites currently use `getPrefixedPV` at the write boundary: `WarningErrorControl.tsx` and `DropDownStateControl.tsx`. See [pv-write-endpoint](../backend/pv-write-endpoint.md).

--- a/docs/frontend/zones.md
+++ b/docs/frontend/zones.md
@@ -1,0 +1,43 @@
+# Zones
+
+Build-time deployment profiles. Each zone declares which routes are reachable and what shows up in the nav bar. The shipped `production` zone is **intentionally empty**.
+
+## Interface
+
+`src/lib/settings/zone-config.ts`:
+
+```ts
+type ZoneConfig = {
+  navigationItems: NavItem[]      // visible nav entries
+  allowedRoutes: string[]         // route paths the middleware allows
+}
+
+const ZONES: Record<string, ZoneConfig> = { test: {...}, production: {...}, ... }
+```
+
+The **adapter** is `src/middleware.ts`. It looks up the zone keyed by `NEXT_PUBLIC_ZONE_CODE` and 302-redirects any request whose path isn't in `allowedRoutes` to `/no-access`. The nav bar reads `navigationItems` from the same source.
+
+## Build-time, not runtime
+
+`NEXT_PUBLIC_*` env vars are baked into the bundle at build time. Switching zones means a rebuild — there is no runtime zone toggle. See [ADR-0002](../adr/0002-zone-based-access-control.md).
+
+## Production override
+
+The `production` zone in the repo is deliberately empty (no allowed routes). For real production builds use one of:
+
+1. **Recommended — per-deployment build env.** Set `NEXT_PUBLIC_ZONE_CODE=<site-zone>` at build time and add a per-site zone entry (e.g. `e3`, `l3bt-hall`, `p3-hall`).
+   - Docker: `docker build --build-arg NEXT_PUBLIC_ZONE_CODE=p3-hall ...`
+   - GitLab CI: project/group variable `NEXT_PUBLIC_ZONE_CODE`
+   - Local prod build: `.env.production`
+2. **Override the empty `production` entry.** Only for one-off deployments. Patch `zone-config.ts` in a fork or at deploy time.
+
+## Adding a page
+
+The middleware enforces zone gating *before* the route handler. If you ship a `page.tsx` without registering it in the relevant zones, the file resolves but every request 302s to `/no-access`. Always:
+
+1. Create the route.
+2. Add it to `allowedRoutes` (and optionally `navigationItems`) of every zone that should reach it.
+
+## Tests
+
+`src/middleware.ts` is in the coverage gate. Tests live next to it; they exercise route allow/deny per zone configuration.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,57 @@
+# Glossary
+
+Two vocabularies, cross-referenced.
+
+The **architecture vocabulary** comes from the [improve-codebase-architecture skill's LANGUAGE.md](../.agents/skills/improve-codebase-architecture/LANGUAGE.md) and is the source of truth — every doc and ADR in this tree uses these terms exactly.
+
+The **domain vocabulary** comes from the EPICS / laser-control world the HMI controls.
+
+## Architecture vocabulary
+
+| Term | Definition |
+| --- | --- |
+| **Module** | Anything with an interface and an implementation. Scale-agnostic (function, class, package, slice). Avoid *unit, component, service*. |
+| **Interface** | Everything a caller must know to use the module: types, invariants, ordering, error modes, configuration, performance. Not just the type signature. |
+| **Implementation** | The code inside a module. |
+| **Adapter** | A concrete thing satisfying an interface at a seam. Describes *role*, not substance. |
+| **Depth** | Leverage at the interface — a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation. |
+| **Seam** *(Feathers)* | Where an interface lives; a place behaviour can be altered without editing in place. Avoid *boundary*. |
+| **Leverage** | What callers get from depth. |
+| **Locality** | What maintainers get from depth: change, bugs, knowledge concentrated in one place. |
+
+Principles drawn from the same source:
+
+- **Deletion test** — if deleting the module concentrates complexity elsewhere, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+## Domain vocabulary
+
+| Term | Meaning | Cross-ref |
+| --- | --- | --- |
+| **PV** | *Process Variable* — a named, typed channel on the EPICS network (e.g. `AI_TEMP_01`). The atomic unit of read/write traffic. | The frontend treats each PV as a *channel* across the WS [seam](architecture.md#seam-1-websocket-pubsub-wspvs). |
+| **EPICS** | Experimental Physics and Industrial Control System. The control-system framework whose PVs we proxy. | The python-backend [module](architecture.md#3-backendpython-websocket-server--fastapi--aioca) is an adapter from EPICS to the WS protocol. |
+| **CA / aioca** | Channel Access (EPICS protocol). `aioca` is the asyncio binding. | Implementation of the python-backend module. |
+| **Severity** | EPICS alarm level on a PV value (0 = NO_ALARM, 1 = MINOR, 2 = MAJOR, 3 = INVALID). | Part of the WS frame interface — see [websocket-protocol](backend/websocket-protocol.md). |
+| **`AI_*` / `BI_*` / `SI_*`** | Mock-backend PV-name prefixes that disambiguate value type: Analog Input (float), Binary Input (bool), String Input. | Encoded in the mock module's implementation. The real EPICS network does not use these prefixes. |
+| **`CMD_*` / `PV_*`** | Command and writable-PV prefixes used by the L4 OPCPA registry. | [pv-naming](reference/pv-naming.md). |
+| **Dev-prefix** | A per-environment prefix (`DEV:`, `STAGE:`, …) prepended to logical PV names at subscribe-time by `getPrefixedPV`. | [pv-naming](reference/pv-naming.md). |
+| **Zone** | A build-time deployment profile that declares which routes are reachable. | The middleware module enforces this — [frontend/zones](frontend/zones.md). |
+| **MSS** | Machine Safety System — the interlock layer that prevents unsafe states. | Surfaced via PVs; the frontend renders state but does not implement it. |
+| **Regen** | Regenerative amplifier in the L4 OPCPA laser chain. | One of the five [LaserPanel](frontend/l4-opcpa.md) sections. |
+| **Flashlamp** | Pump-light source for laser amplifiers; arranged in channels with timing and energy controls. | Section of the LaserPanel. |
+| **Modbox** | A box of modulator-control electronics for the laser; per-channel modulator parameters. | Section of the LaserPanel. |
+| **Modbox / OPCPA** | Optical Parametric Chirped-Pulse Amplification — the laser architecture L4 uses. | Subject of [frontend/l4-opcpa](frontend/l4-opcpa.md). |
+| **L3 / L4 / P3** | Beamlines / module identifiers. Each currently has a control page. | [frontend/module-pages](frontend/module-pages.md). |
+| **Operator station** | A locked-down browser on a control-room machine. | [runbooks/operator-stations](runbooks/operator-stations.md). |
+
+## Cross-references
+
+| Domain term | Lives behind which **seam** / **module**? |
+| --- | --- |
+| PV (subscribe path) | WS pub/sub seam → `useWebSocketData` adapter |
+| PV (write path) | `POST /pv/<NAME>` seam → `fetch` adapter |
+| Severity, units, timestamp | WS frame interface |
+| Dev-prefix | Module-internal: `getPrefixedPV` in the frontend WS client implementation |
+| Zone | Module-internal seam: middleware adapter over zone-config interface |
+| Regen / Flashlamp / Modbox | Implementation detail of the LaserPanel module (compound component) |

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -1,0 +1,61 @@
+# Env vars
+
+Consolidated reference across the three modules. *Source of truth, not aspiration* — vars listed here are the ones the code reads today.
+
+## Frontend (`frontend/.env.local`)
+
+| Var | Required | Default | Used for |
+| --- | --- | --- | --- |
+| `NEXTAUTH_SECRET` | yes | — | NextAuth JWT signing |
+| `NEXTAUTH_URL` | dev | `http://localhost:8080/api/auth` | NextAuth callback base — set per host |
+| `NEXT_PUBLIC_API_URL` | yes | — | host:port for both `ws://<host>/ws/pvs` and `http://<host>/pv` (see `frontend/src/types/constants.ts`) |
+| `NEXT_PUBLIC_ZONE_CODE` | yes | (empty zone = no routes) | Build-time zone selector — see [zones](../frontend/zones.md) |
+| `LDAP_SERVER_URL` | prod | — | LDAP bind URL for the production auth path |
+| `LDAP_BASE_DN` | prod | — | LDAP base DN |
+| `LDAP_USE_TLS` | optional | `false` | Toggle StartTLS on the LDAP bind |
+| `NODE_ENV` | optional | `development` | Standard Node env |
+
+A template lives at `frontend/env.example`.
+
+⚠ **Naming.** `AGENTS.md` and older READMEs refer to `NEXT_PUBLIC_WEBSOCKET_URL`. The code (since the L4 OPCPA work) uses `NEXT_PUBLIC_API_URL` as the single host:port for both WS and write traffic. If you see the older variable name in legacy docs, treat it as a synonym for `NEXT_PUBLIC_API_URL`.
+
+`NEXT_PUBLIC_*` is baked at build time. Changing them post-build requires a rebuild.
+
+## Mock backend (Go)
+
+No env vars. Tuning is via constants at the top of `main.go`:
+
+```go
+var (
+    aiMode = 1            // 1 = auto-simulate, 2 = manual
+    biMode = 2
+    siMode = 2
+    updatePeriodMs = 300
+)
+```
+
+Edit + `go run main.go`. Listens on `:8080`.
+
+## Python backend (FastAPI + aioca)
+
+| Var | Default | Notes |
+| --- | --- | --- |
+| `HOST` | `127.0.0.1` (Makefile) / `0.0.0.0` (image) | Bind address |
+| `PORT` | `8000` (Makefile) / `8080` (container internal) | Bind port |
+| `LOG_LEVEL` | `INFO` | Standard log levels |
+| `LOG_JSON` | `false` | Switch logs to JSON |
+| `DEFAULT_TIMEOUT` | `2.0` | aioca read timeout in seconds |
+| `MAX_TIMEOUT` | `30.0` | Upper bound on per-request timeout |
+| `MAX_PVS_PER_SUBSCRIPTION` | `64` | Limit emitted in the `connected` frame |
+| `MAX_SUBSCRIPTIONS_PER_CONNECTION` | `32` | Same |
+| `ENABLE_DOCS` | `true` | Toggle `/docs` and `/redoc` |
+
+Plus standard aioca-side EPICS env (`EPICS_CA_ADDR_LIST`, `EPICS_CA_AUTO_ADDR_LIST`, etc.) for talking to a real EPICS network.
+
+Run with `make dev` (foreground reload) or `make run` (no reload). Docker entrypoint binds 8080 internally; the Makefile's `docker-run` target maps `$(PORT):8080`.
+
+## Authoring guidelines
+
+- Never commit secrets — use `.env.local` (frontend) or process-injected env (backends).
+- `NEXT_PUBLIC_*` ends up in the browser bundle. Don't put anything sensitive there.
+- New env vars should be added to: the relevant code path, the `env.example` template (frontend), this page, and the README of the affected module.

--- a/docs/reference/pv-naming.md
+++ b/docs/reference/pv-naming.md
@@ -1,0 +1,42 @@
+# PV naming
+
+How PV names are written in code, what the wire sees, and which prefixes mean what.
+
+## Logical vs wire names
+
+Code uses *logical* PV names (`MOD1.AI_TEMP`). The frontend WS client applies a per-environment **dev-prefix** via `getPrefixedPV` (`frontend/src/lib/utils/pv-helpers.ts`) at subscribe time and at lookup time. The wire sees the prefixed form (e.g. `DEV:MOD1:AI_TEMP`).
+
+Callers stay in logical names. The hook is the deep module that buries this — see [websocket-client](../frontend/websocket-client.md). The only place this discipline currently breaks is two write call sites that call `getPrefixedPV` themselves (`WarningErrorControl.tsx`, `DropDownStateControl.tsx`).
+
+## Mock-backend prefix conventions
+
+The Go mock infers the value type from a prefix on the **last** name segment:
+
+| Prefix | Type | Default mode | Use |
+| --- | --- | --- | --- |
+| `AI_*` | float64 | auto-simulate (drift) | Analog Input — pressures, temperatures, RPMs |
+| `BI_*` | bool | manual | Binary Input — door open/closed, valve open/closed |
+| `SI_*` | string | manual (cycles preset words) | String Input — state labels |
+| `CMD_*` | (command) | n/a | L4 OPCPA: write triggers a coordinated effect chain |
+| `PV_*` | direct PV | n/a | L4 OPCPA: writable PV that isn't a command |
+
+These conventions are **mock-only**. The real EPICS network does not use them. If you write a page against the mock with `AI_RPM_TURBO`, the same logical name on the python-backend resolves to whatever the EPICS database calls that PV — the dev-prefix is the only convention shared between the two backends.
+
+## L4 OPCPA registry
+
+The laser-control page constructs every PV name through typed builders:
+
+```ts
+import { pv } from '@/app/(modules)/l4-opcpa/lib/pv-names'
+
+pv.shutter('NL2')                        // 'BI_NL2_SHUTTER'
+pv.flashlampChannel('NL2', '22', '1')    // 'SI_NL2_FL_22_CH1'
+pv.cmd('NL2', 'START_LASER')             // 'CMD_NL2_START_LASER'
+pv.mssAll('NL2', 6)                      // ['BI_NL2_MSS_1', …, 'BI_NL2_MSS_6']
+```
+
+The mock (`backend/mockup-websocket-server/l4_opcpa.go`) hand-mirrors the same name shapes. See [ADR-0006](../adr/0006-pv-name-registry-l4-opcpa.md).
+
+## Deliberate placeholders
+
+`src/lib/modules/<m>.config.ts` files carry placeholder PV names — `undefined1:PRESSURE`, `SI_???`, `AI_RPM_SPEED_P04`, `// TODO PV name unclear`, `// TODO PVs unknown`. These are **deliberate**, not oversights. Control engineers haven't settled on canonical names yet; the refactor preserves the legacy ambiguity rather than inventing names. Replace placeholders only when an engineer has confirmed them. Detail: [`frontend/src/lib/modules/README.md`](../../frontend/src/lib/modules/README.md#deliberate-placeholders).

--- a/docs/runbooks/deploying-python-backend.md
+++ b/docs/runbooks/deploying-python-backend.md
@@ -1,0 +1,57 @@
+# Deploying the Python backend
+
+Production target. Currently runs as a Docker container pushed to the ELI Harbor registry; the frontend Docker build is tracked separately and is not yet wired up in CI.
+
+## Pipeline
+
+`.gitlab-ci.yml` job `docker-build-job` does:
+
+1. `docker login` to `harbor.eli-beams.eu` with `${HARBOR_USERNAME}` / `${HARBOR_PASSWORD}`.
+2. `cd backend/python-websocket-server`.
+3. `docker build . -t ${HARBOR_HOST}/${HARBOR_PROJECT}/eli-hmi-backend-python:latest -f Dockerfile`.
+4. `docker push` of the resulting tag.
+
+Frontend and mock-backend image builds are commented out in the same job (the commented `docker build … eli-hmi-frontend:latest` lines).
+
+## What the container expects
+
+| Var | Effect |
+| --- | --- |
+| `HOST` / `PORT` | Bind. Container exposes 8080 internally; map externally as needed. |
+| `EPICS_CA_ADDR_LIST` / `EPICS_CA_AUTO_ADDR_LIST` | Where aioca looks for IOCs. **Without these, reads time out and `/health/ready` never reports `ready`.** |
+| `LOG_LEVEL`, `LOG_JSON` | Logging. JSON logs are friendlier for the production log pipeline. |
+| `DEFAULT_TIMEOUT`, `MAX_TIMEOUT` | aioca read timeouts. Tune to the slowest IOC you talk to. |
+| `MAX_PVS_PER_SUBSCRIPTION`, `MAX_SUBSCRIPTIONS_PER_CONNECTION` | Soft limits, advertised in the `connected` frame. |
+| `ENABLE_DOCS` | Set to `false` to disable `/docs` and `/redoc` in production. |
+
+See [reference/env-vars](../reference/env-vars.md) for defaults.
+
+## Health checks for the orchestrator
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /health/live` | Liveness — the process is up. Return `{"status":"live"}`. |
+| `GET /health/ready` | Readiness — the EPICS connection pool has initialised. Returns `{"status":"ready"}` once `ws_manager.ready` is true. |
+
+If `ready` never flips, the most common cause is missing `EPICS_CA_ADDR_LIST` or unreachable IOCs.
+
+## Stats / observability
+
+- `GET /stats` — JSON. Connection count, monitor count, subscriber counts, per-monitor cached values.
+- `GET /stats/ui` — HTML dashboard that polls `/stats`.
+
+These are intended for internal diagnostics. If you front them behind a reverse proxy, gate them by IP or auth.
+
+## Rollback
+
+There's no published version tag yet (image is `:latest`). If a rollback is needed:
+
+1. Pull the previous SHA from the Harbor registry.
+2. Re-tag it as `:latest` and push.
+3. Restart the orchestrator pod/service so it picks up the new image.
+
+This is brittle. A `vX.Y.Z` tagging policy is worth introducing — out of scope of this doc.
+
+## Source-of-truth README
+
+[`backend/python-websocket-server/README.md`](../../backend/python-websocket-server/README.md).

--- a/docs/runbooks/local-dev.md
+++ b/docs/runbooks/local-dev.md
@@ -1,0 +1,81 @@
+# Local dev
+
+End-to-end. Fresh clone to running UI in five steps.
+
+## Prerequisites
+
+- Node 20.x (matches the CI image)
+- Go 1.22+ (for the mock backend)
+- (Optional) Python 3.12 + EPICS libs if you want to run the production server locally
+
+## Steps
+
+```bash
+# 1. Frontend deps
+cd frontend
+npm install
+
+# 2. Env
+cp env.example .env.local
+# edit .env.local — set NEXTAUTH_SECRET to any strong random value
+# NEXT_PUBLIC_API_URL=localhost:8080 (the mock)
+# NEXT_PUBLIC_ZONE_CODE=test
+
+# 3. Mock backend (in another terminal)
+cd ../backend/mockup-websocket-server
+go run main.go
+# listens on :8080
+
+# 4. Frontend dev server
+cd ../../frontend
+npm run dev
+# http://localhost:8082  (port 8082, not 3000)
+
+# 5. Log in
+# username: test   password: test
+```
+
+If the WebSocket reconnect spinner stays on the screen, the mock isn't up — or `NEXT_PUBLIC_API_URL` doesn't match the mock's port. See [running-mock-backend](running-mock-backend.md).
+
+## Tests
+
+```bash
+cd frontend
+npm test                  # watch
+npm run test:run          # one-shot
+npm run test:coverage     # coverage gate (70/70/70/60 on covered scope)
+npm run lint
+```
+
+Two WebSocket test seams are described in [overview](../frontend/overview.md#test-seams).
+
+## Useful side-doors against the mock
+
+```bash
+# set an analog input
+curl http://localhost:8080/pv/AI_TEMP/37.0
+
+# trip a binary input
+curl http://localhost:8080/pv/BI_DOOR/true
+
+# switch BI_* to auto-simulate (default is manual)
+curl http://localhost:8080/mode/BI/1
+
+# L4 OPCPA: enable 10 % write-failure injection
+curl http://localhost:8080/mode/fail-rate/10
+```
+
+See [running-mock-backend](running-mock-backend.md) for the rest.
+
+## Optional: Python backend instead of mock
+
+Only if you need to verify against a real EPICS network. See [running-python-backend](running-python-backend.md). Note: the Python server speaks a [different WS dialect](../backend/websocket-protocol.md) — the frontend currently cannot consume it directly.
+
+## Where to ask
+
+If you're stuck on something not covered here, the canonical references are:
+
+- [frontend/README.md](../../frontend/README.md)
+- [frontend/AGENTS.md](../../frontend/AGENTS.md)
+- [backend/mockup-websocket-server/readme.md](../../backend/mockup-websocket-server/readme.md)
+- [backend/python-websocket-server/README.md](../../backend/python-websocket-server/README.md)

--- a/docs/runbooks/operator-stations.md
+++ b/docs/runbooks/operator-stations.md
@@ -1,0 +1,55 @@
+# Operator stations
+
+The browser-locked machines in the control room that operators use day-to-day. Each station is locked to a single **zone** ([zones](../frontend/zones.md)).
+
+## Station-level configuration
+
+1. **Browser.** Chromium or Firefox in kiosk mode pointing at `http://<frontend-host>:8082/`. Kiosk config is the OS distribution's job; the HMI itself doesn't enforce it.
+2. **Zone.** The frontend bundle deployed to that station is built with `NEXT_PUBLIC_ZONE_CODE=<station-zone>` (e.g. `e3`, `l3bt-hall`, `p3-hall`). Switching zones requires a rebuild — `NEXT_PUBLIC_*` is baked at build time.
+3. **Backend URL.** `NEXT_PUBLIC_API_URL=<backend-host>:<port>` baked into the same build. The same host:port serves both the WebSocket (`/ws/pvs`) and the write endpoint (`/pv/<NAME>`).
+
+## Adding a new station / zone
+
+1. Decide which routes that station needs.
+2. Add a zone entry in `frontend/src/lib/settings/zone-config.ts`:
+
+   ```ts
+   'l3bt-hall': {
+     navigationItems: [
+       { text: 'L3BT', href: '/l3bt-controls' },
+     ],
+     allowedRoutes: ['/l3bt-controls'],
+   }
+   ```
+
+3. Build the frontend with that zone:
+
+   ```bash
+   docker build \
+     --build-arg NEXT_PUBLIC_ZONE_CODE=l3bt-hall \
+     --build-arg NEXT_PUBLIC_API_URL=epics-gateway.lcs.local:8080 \
+     -t harbor.eli-beams.eu/.../eli-hmi-frontend:l3bt-hall ...
+   ```
+
+4. Deploy that image to the station.
+
+The shipped `production` zone in `zone-config.ts` is **intentionally empty** — see [zones](../frontend/zones.md#production-override).
+
+## Login
+
+Operators authenticate via LDAP credentials. The dev bypass (`test`/`test`) only works because of a literal-string check in `ldap-auth.ts` — it is **not** disabled by `NODE_ENV=production`. Audit your build before shipping.
+
+## When something breaks at the station
+
+| Symptom | Likely cause | First check |
+| --- | --- | --- |
+| Login succeeds; nav bar empty | Zone has no `navigationItems` | `zone-config.ts` for the station's zone |
+| Login succeeds; clicking a link redirects to `/no-access` | Route not in `allowedRoutes` for the zone | Same |
+| WebSocket spinner forever | Backend unreachable or wrong host:port | `NEXT_PUBLIC_API_URL` baked in, network path to backend |
+| Backend reachable; readings show `<>` glyphs | Subscribed PV doesn't exist on the backend | Mock prefix conventions ([pv-naming](../reference/pv-naming.md)) or EPICS IOC reachability |
+| Writes silently fail with error toast | Mock failure injection on, or write endpoint not yet implemented on prod backend | `curl http://<backend>/mode/fail-rate/0` (mock); [pv-write-endpoint](../backend/pv-write-endpoint.md) (prod) |
+
+## Source-of-truth READMEs
+
+- [frontend/README.md](../../frontend/README.md)
+- [frontend/AGENTS.md](../../frontend/AGENTS.md)

--- a/docs/runbooks/running-mock-backend.md
+++ b/docs/runbooks/running-mock-backend.md
@@ -1,0 +1,72 @@
+# Running the mock backend
+
+Single Go binary. No deps beyond `go.mod`. Listens on `:8080`.
+
+## Quick run
+
+```bash
+cd backend/mockup-websocket-server
+go run main.go
+```
+
+Or build once and run repeatedly:
+
+```bash
+go build
+./eli-hmi-mockup-websocket-server
+```
+
+## Docker
+
+```bash
+docker build -t mockup-ws-gateway .
+docker run -p 8080:8080 mockup-ws-gateway
+```
+
+## Endpoints summary
+
+See [backend/mock-server](../backend/mock-server.md) for the full table. The ones you'll actually hit by hand:
+
+```bash
+# Set values (GET so you can hit it from a browser)
+curl http://localhost:8080/pv/AI_TEMP/37.0
+curl http://localhost:8080/pv/BI_DOOR/true
+
+# Mode flips per prefix: 1 = auto-simulate, 2 = manual
+curl http://localhost:8080/mode/AI/1
+curl http://localhost:8080/mode/BI/2
+
+# L4 OPCPA write-failure injection (0 disables; default in code is 0)
+curl http://localhost:8080/mode/fail-rate/10
+
+# Inspect the L4 OPCPA waveform catalog
+curl http://localhost:8080/waveforms
+```
+
+## Tuning
+
+Edit constants at the top of `main.go`:
+
+```go
+var (
+    aiMode = 1            // 1 = auto-simulate, 2 = manual
+    biMode = 2
+    siMode = 2
+    updatePeriodMs = 300  // broadcast period
+    randomWords = []string{ ... }
+)
+```
+
+Re-run `go run main.go` to pick up changes.
+
+## L4 OPCPA seed data
+
+`seedLaserPVs()` (called from `main()`) populates default at-rest values for all 5 lasers on startup. Effect-chain writes (via `CMD_*` PVs) hold for 3 s before releasing back to auto-simulated drift around the last-set value. The hand-mirrored PV registry lives in `l4_opcpa.go` — keep it in sync with `frontend/src/app/(modules)/l4-opcpa/lib/pv-names.ts`.
+
+## Stopping
+
+Ctrl-C. No persistent state to clean up.
+
+## Source-of-truth README
+
+[`backend/mockup-websocket-server/readme.md`](../../backend/mockup-websocket-server/readme.md).

--- a/docs/runbooks/running-python-backend.md
+++ b/docs/runbooks/running-python-backend.md
@@ -1,0 +1,85 @@
+# Running the Python backend
+
+FastAPI + aioca. Read/monitor only at present (no write endpoint).
+
+## Quick run (Makefile)
+
+```bash
+cd backend/python-websocket-server
+make install         # creates .venv, installs requirements
+make dev             # fastapi dev server.py --host 127.0.0.1 --port 8000
+```
+
+Production-style local run (no auto-reload):
+
+```bash
+make run
+```
+
+Override host/port:
+
+```bash
+make dev HOST=127.0.0.1 PORT=8090
+```
+
+## Direct invocation
+
+```bash
+source .venv/bin/activate
+fastapi dev server.py --host 127.0.0.1 --port 8000
+# or, prod-style:
+fastapi run server.py --host 127.0.0.1 --port 8000
+```
+
+## Docker
+
+```bash
+make docker-build           # tag: eli-hmi-epics-gateway
+make docker-run             # maps $(PORT):8080
+```
+
+The container entrypoint runs `fastapi run server.py` on internal port 8080.
+
+## EPICS environment
+
+aioca needs to find your IOCs. Standard EPICS env vars:
+
+```
+EPICS_CA_ADDR_LIST=10.78.0.50 10.78.0.51
+EPICS_CA_AUTO_ADDR_LIST=NO
+EPICS_CA_SERVER_PORT=5064
+```
+
+Without these, reads will time out and `/health/ready` will report `starting` indefinitely.
+
+## Verify
+
+```bash
+# Landing page (HTML)
+curl http://localhost:8000/
+
+# Health
+curl http://localhost:8000/health/live
+curl http://localhost:8000/health/ready
+
+# Read a PV
+curl "http://localhost:8000/pv/DEVICE:PV?detail=control&timeout=2.5"
+
+# Stats
+curl http://localhost:8000/stats          # JSON
+open  http://localhost:8000/stats/ui      # HTML dashboard
+```
+
+## Connecting the frontend (with caveats)
+
+The frontend currently emits the [mock dialect](../backend/websocket-protocol.md). Pointing `NEXT_PUBLIC_API_URL` at this server's host:port will fail until [ADR-0009](../adr/0009-shared-ws-protocol-contract.md) resolves the protocol gap.
+
+For read-only verification, hit `GET /pv/<name>` directly from `curl` or the OpenAPI UI at `/docs`.
+
+## Stopping
+
+Ctrl-C in dev. For Docker: `docker stop <container>`.
+
+## Source-of-truth README
+
+[`backend/python-websocket-server/README.md`](../../backend/python-websocket-server/README.md).

--- a/docs/workflows/adding-a-control-page.md
+++ b/docs/workflows/adding-a-control-page.md
@@ -1,0 +1,119 @@
+# Workflow: adding a control page
+
+For a *vacuum-system* control page (L3BT, L4fBT, P3 shape). If the page is laser-control-shaped, see [l4-opcpa](../frontend/l4-opcpa.md) — that pattern is deliberately different.
+
+## Steps
+
+### 1. Write the config
+
+`frontend/src/lib/modules/<m>.config.ts`:
+
+```ts
+import type { ModuleConfig } from './types'
+
+export const myModuleConfig: ModuleConfig = {
+  heading: 'My Module',
+  interlocks: {
+    title: 'My Module Interlocks',
+    checkClearPv: 'MY-MODULE:INTERLOCK',
+    items: [
+      { pvname: 'MY-MODULE:S1:INTERLOCK', title: 'Volume S1' },
+    ],
+  },
+  safetyPermission: { title: '…', items: [/* … */] },
+  cleanDryAir: {
+    title: 'My Module CDA',
+    volumes: [
+      {
+        title: 'CDA Valve Actuation',
+        pressure: { pvName: 'MY:PPS:PRESSURE', label: 'PPS' },
+        flow: { pvName: 'MY:PPS:FLOW', label: 'PFS', options: { format: 'precision' } },
+      },
+    ],
+  },
+  backing: { /* SensorGroup + PumpConfig */ },
+  roughing: { /* SensorGroup + PumpConfig + optional Locking */ },
+}
+```
+
+### 2. Add the page
+
+`frontend/src/app/(modules)/<m>-controls/page.tsx`:
+
+```tsx
+'use client'
+import { ModuleControlPage } from '@/components/module-page/module-control-page'
+import { myModuleConfig } from '@/lib/modules/<m>.config'
+import { MyVolumes } from './parts/volumes'
+import { MyConnector } from './parts/connector'
+
+export default () => (
+  <ModuleControlPage
+    config={myModuleConfig}
+    bottomRow={
+      <>
+        <MyConnector />
+        <MyVolumes />
+      </>
+    }
+  />
+)
+```
+
+### 3. Build the `parts/`
+
+Anything not data-only (volumes with mixed compound children, connectors with cross-module hyperlinks, etc.) lives in `frontend/src/app/(modules)/<m>-controls/parts/` as React components. Use the compound HMI building blocks — [hmi-components](../frontend/hmi-components.md).
+
+### 4. Register the route in a zone
+
+`frontend/src/lib/settings/zone-config.ts`:
+
+```ts
+test: {
+  navigationItems: [
+    /* existing … */
+    { text: 'My Module', href: '/<m>-controls' },
+  ],
+  allowedRoutes: [
+    /* existing … */
+    '/<m>-controls',
+  ],
+}
+```
+
+Skip this and the middleware redirects to `/no-access` even though the file exists.
+
+### 5. Test it
+
+```bash
+npm test                # vitest watch
+npm run dev             # localhost:8082
+```
+
+Hit the new page; subscribe traffic should appear in the network panel.
+
+### 6. Mock PVs if needed
+
+For PV names that don't exist on the mock backend by prefix convention, set them by hand:
+
+```bash
+curl http://localhost:8080/pv/AI_PRESSURE/0.1
+curl http://localhost:8080/pv/BI_INTERLOCK/true
+```
+
+### 7. Add coverage
+
+`src/components/module-page/**` is inside the [coverage gate](../frontend/overview.md#coverage-gate). Add tests for new panel renderings and edge cases.
+
+## Reusing what's there
+
+| You want… | Reach for… |
+| --- | --- |
+| To render a panel of interlocks | `interlocks` in `ModuleConfig` |
+| To render a sensor bar | `backing.sensorBar` / `roughing.sensorBar` |
+| A pump readout with RPM + valve | `backing.pump` / `roughing.pump` |
+| A CDA volume row | `cleanDryAir.volumes[]` |
+| A bespoke volume layout (anything non-uniform) | A React component in `parts/`, composed from `VolumePanel.*` |
+| A connector / valve diagram | `ConnectorLine.*` in `parts/` |
+
+See [module-pages](../frontend/module-pages.md) and the canonical [`src/lib/modules/README.md`](../../frontend/src/lib/modules/README.md).

--- a/docs/workflows/adding-a-pv-to-mock-backend.md
+++ b/docs/workflows/adding-a-pv-to-mock-backend.md
@@ -1,0 +1,94 @@
+# Workflow: adding a PV to the mock backend
+
+When a frontend page needs a PV the mock doesn't synthesise by prefix convention. Most PVs work out-of-the-box — the mock infers value type from prefix (`AI_*` / `BI_*` / `SI_*`). The cases below are the ones that need explicit code.
+
+## Case 1: PV that fits the prefix convention
+
+Nothing to do. Subscribe to the PV from the frontend and the mock will:
+
+- spawn a `pvSim` goroutine for it on first subscribe
+- broadcast a value every ~300 ms
+- shut down the simulator when the last subscriber disconnects
+
+If you want a specific value while developing:
+
+```bash
+curl http://localhost:8080/pv/AI_TEMP/37.0
+curl http://localhost:8080/pv/BI_DOOR/true
+```
+
+If the prefix-default mode is wrong (e.g. you want `BI_*` to auto-toggle):
+
+```bash
+curl http://localhost:8080/mode/BI/1   # 1=auto, 2=manual
+```
+
+## Case 2: PV that doesn't fit the prefix convention
+
+The mock will return `ok:false` for any PV whose last segment doesn't start with `AI_`, `BI_`, `SI_`, `CMD_`, or `PV_`. Options:
+
+- **Rename the logical PV** in the frontend to fit a prefix. Cheapest.
+- **Hand-mirror** the PV in `backend/mockup-websocket-server/main.go` (or `l4_opcpa.go` for laser-control PVs). Add it to the prefix map or the L4 seed function.
+
+## Case 3: L4 OPCPA PV
+
+These are listed canonically in `frontend/src/app/(modules)/l4-opcpa/lib/pv-names.ts`. The mock hand-mirrors the same names in `backend/mockup-websocket-server/l4_opcpa.go`.
+
+To add a new L4 PV:
+
+1. Add a builder to `pv-names.ts`:
+
+   ```ts
+   export const pv = {
+     // … existing builders …
+     myNewSignal: (laser: string) => `AI_${laser}_MY_NEW_SIGNAL` as const,
+   }
+   ```
+
+2. Add a corresponding entry in `l4_opcpa.go` so the mock seeds it with a sensible default.
+
+3. Add an integration test next to `pv-names.test.ts` to lock the wire-name shape.
+
+4. Use `pv.myNewSignal('NL2')` from a section component — never inline the string.
+
+See [ADR-0006](../adr/0006-pv-name-registry-l4-opcpa.md).
+
+## Case 4: Write-side PV
+
+The mock honors `POST /pv/<NAME>` and `PUT /pv/<NAME>`. Writes:
+
+- update the simulator's last value immediately
+- broadcast a `pv` frame to subscribers
+- for L4 OPCPA `CMD_*` PVs: dispatch a coordinated effect chain (held for 3 s then released to drift)
+
+If you're adding a CMD PV that should trigger an effect chain, register the dispatch in `l4_opcpa.go` next to the existing chains.
+
+Failure injection helps exercise frontend error UI:
+
+```bash
+curl http://localhost:8080/mode/fail-rate/10
+```
+
+## Adding a value-type domain mode
+
+If you need a new prefix family (e.g. `WI_*` for waveforms), edit `main.go`:
+
+- Add the mode constant (`wiMode`).
+- Add the type-inference branch in `synthValue()` / `loop()`.
+- Wire the REST helpers (`/pv/:n/:v`, `/mode/:p/:v`) to parse the new value type.
+
+This is rare — get a review.
+
+## Verify
+
+```bash
+# Send a subscribe by hand
+websocat 'ws://localhost:8080/ws/pvs?auth=test'
+> {"type":"subscribe","pvs":{"AI_MY_NEW_PV":true}}
+```
+
+You should see `{"type":"pv","name":"AI_MY_NEW_PV", ...}` frames within ~300 ms.
+
+## Source-of-truth README
+
+[`backend/mockup-websocket-server/readme.md`](../../backend/mockup-websocket-server/readme.md).

--- a/docs/workflows/adding-an-adr.md
+++ b/docs/workflows/adding-an-adr.md
@@ -1,0 +1,73 @@
+# Workflow: adding an ADR
+
+ADRs (Architecture Decision Records) live in `docs/adr/`. Each captures one load-bearing decision so future architecture reviews don't re-litigate it.
+
+## When to write one
+
+Write an ADR when:
+
+- a change you made (or rejected) only makes sense given a constraint a fresh contributor wouldn't immediately see
+- you considered a refactor and rejected it for a reason that should outlast the conversation
+- you took a path that contradicts what a casual reader would assume — and you don't want the next reader to "fix" it
+
+**Don't** write an ADR for:
+
+- bug fixes
+- choices that are self-evident from the code or its tests
+- ephemeral decisions ("not worth it right now")
+- anything the [architecture skill's SKILL.md](../../.agents/skills/improve-codebase-architecture/SKILL.md) would call "self-evident choices"
+
+If you're not sure, the heuristic from the skill applies: *would a future architecture review re-suggest this if the ADR didn't exist?* If yes, write it.
+
+## Numbering
+
+ADRs are sequential, zero-padded to four digits, starting at `0001`. Look at `docs/adr/` and take the next number. The template at [`docs/adr/template.md`](../adr/template.md) is **unnumbered** — copy it, don't number it.
+
+## Format
+
+Use the template literally:
+
+```markdown
+# ADR-NNNN: <title>
+
+**Status:** Accepted | Superseded by ADR-NNNN | Deprecated
+**Date:** YYYY-MM-DD
+**Deciders:** @user1, @user2
+
+## Context
+What forces are at play. What we tried. What we observed.
+
+## Decision
+The decision, in one paragraph. Use module/interface/seam/etc. where it sharpens the claim.
+
+## Consequences
+- Positive: leverage / locality gained.
+- Negative: complexity introduced, work pushed elsewhere.
+- Open: what remains undecided, what triggers revisiting.
+
+## Alternatives considered
+Short list, with one-line reason each was rejected.
+```
+
+## Vocabulary
+
+Use the architecture vocabulary from [glossary](../glossary.md) and the [LANGUAGE.md](../../.agents/skills/improve-codebase-architecture/LANGUAGE.md) **exactly**: *module / interface / implementation / adapter / depth / seam / leverage / locality*. Don't drift into *component / service / API / boundary*.
+
+## After writing
+
+1. Add the ADR to the index in [`docs/README.md`](../README.md).
+2. Run `node scripts/docs/check-index.js` and `node scripts/docs/check-links.js` — both must pass.
+3. Link to the ADR from the docs whose claim it backs (architecture, frontend/, backend/, runbooks/, …). One backlink per dependent doc is enough.
+4. Commit on a feature branch and open a PR. Use the PR description to explain why the ADR was needed *now* — the ADR itself describes the decision, not the meta.
+
+## Superseding an existing ADR
+
+- Don't edit the original. Mark its status `Superseded by ADR-NNNN`.
+- Write the new ADR; in its `Context`, link back to the one it supersedes and summarise what changed.
+- Update both index entries.
+
+## Don't
+
+- Don't duplicate prose between the ADR and a doc page. The ADR is the authoritative record; the doc page can summarise and link.
+- Don't number the template.
+- Don't ADR-ify a refactor that hasn't shipped. ADRs are about decisions whose consequences are already in tree.

--- a/docs/workflows/publishing-wiki.md
+++ b/docs/workflows/publishing-wiki.md
@@ -61,7 +61,7 @@ Most failures are one of:
 
 - **Broken internal link.** `check-links.js` is the gate that should have caught this — re-run it locally and fix.
 - **Wiki repo doesn't exist.** Enable the wiki under repo settings before the first sync.
-- **Permission denied pushing to wiki.** The default `GITHUB_TOKEN` should suffice (`contents: write`); if a fine-grained PAT is in use, re-issue.
+- **Permission denied pushing to wiki.** The workflow uses a repo secret named `WIKI_TOKEN` (PAT or fine-grained token with wiki write scope). If pushes 403, the token is missing or has expired — re-issue it under repo Settings → Secrets and variables → Actions.
 
 ## Source
 

--- a/docs/workflows/publishing-wiki.md
+++ b/docs/workflows/publishing-wiki.md
@@ -1,0 +1,70 @@
+# Workflow: publishing to the wiki
+
+`docs/` is mirrored to the [GitHub Wiki](https://github.com/eli-eric/eli-hmi/wiki) on every push to `dev`. The mirror is one-way — edit `docs/` in this repo, never the wiki directly.
+
+## What triggers a sync
+
+The workflow `.github/workflows/sync-docs-to-wiki.yml` runs on:
+
+- `push` to the `dev` branch
+- with at least one path under `docs/**`
+
+A push that doesn't touch `docs/` doesn't run the workflow. A push to any other branch doesn't run it either. (Production-zone style — make the constraint explicit and don't introduce a runtime override.)
+
+## What the sync does
+
+1. Checks out the repo.
+2. Clones the wiki: `git clone https://x-access-token:$TOKEN@github.com/$REPO.wiki.git wiki/`.
+3. Runs `node scripts/docs/sync-to-wiki.js docs/ wiki/`. The script:
+   - flattens subdirectories with a `<dir>-` prefix (`docs/adr/0005-...` → `wiki/adr-0005-...md`)
+   - rewrites in-tree relative links (`./adr/0005-x.md` → `[[adr-0005-x]]`)
+   - copies `docs/README.md` to `wiki/Home.md`
+   - deletes wiki pages that no longer have a counterpart under `docs/`
+4. Commits and pushes to the wiki repo.
+
+Concurrency is gated by a `wiki-sync` group so two parallel runs can't interleave commits.
+
+## How to verify a change before merging
+
+1. Run the local checks:
+
+   ```bash
+   node scripts/docs/check-index.js
+   node scripts/docs/check-links.js
+   ```
+
+   Both must exit 0.
+
+2. (Optional, for risky changes) Test the rewrite against a sandbox wiki:
+
+   ```bash
+   # Make sure you have write access to a throwaway wiki repo, then:
+   git clone <throwaway>.wiki.git /tmp/sandbox-wiki
+   node scripts/docs/sync-to-wiki.js docs/ /tmp/sandbox-wiki
+   cd /tmp/sandbox-wiki && git diff
+   ```
+
+   Inspect the rewrite and rendered pages.
+
+3. Merge to `dev`. The workflow runs; check the Actions tab.
+
+## Authoring rules
+
+- Use **kebab-case** filenames. Subdirectory + filename together form the wiki page name after flattening (`adr-0005-single-pv-write-endpoint`).
+- Use **relative** in-tree links (`./adr/0005-x.md`, `../frontend/zones.md`). External URLs (`https://…`) and anchor-only (`#section`) links pass through unchanged.
+- Don't link to files outside `docs/` unless you accept that wiki readers will see a 404 if they click. The sync deliberately does not rewrite cross-repo links.
+- Don't write new top-level pages in the wiki UI. They'll be deleted on the next sync.
+
+## When the sync fails
+
+Most failures are one of:
+
+- **Broken internal link.** `check-links.js` is the gate that should have caught this — re-run it locally and fix.
+- **Wiki repo doesn't exist.** Enable the wiki under repo settings before the first sync.
+- **Permission denied pushing to wiki.** The default `GITHUB_TOKEN` should suffice (`contents: write`); if a fine-grained PAT is in use, re-issue.
+
+## Source
+
+- Workflow: [`.github/workflows/sync-docs-to-wiki.yml`](../../.github/workflows/sync-docs-to-wiki.yml)
+- Script: [`scripts/docs/sync-to-wiki.js`](../../scripts/docs/sync-to-wiki.js)
+- Validators: [`scripts/docs/check-index.js`](../../scripts/docs/check-index.js), [`scripts/docs/check-links.js`](../../scripts/docs/check-links.js)

--- a/frontend/src/app/(modules)/l4-opcpa/README.md
+++ b/frontend/src/app/(modules)/l4-opcpa/README.md
@@ -1,5 +1,7 @@
 # L4 OPCPA Control System
 
+> Architecture context: [`docs/frontend/l4-opcpa.md`](../../../../../docs/frontend/l4-opcpa.md). Related ADRs: [0006](../../../../../docs/adr/0006-pv-name-registry-l4-opcpa.md), [0007](../../../../../docs/adr/0007-l4-custom-shell-not-modulecontrolpage.md), [0008](../../../../../docs/adr/0008-laser-specs-location.md).
+
 Operator UI for the L4 OPCPA laser system. Five lasers (NL1–NL5) rendered
 side-by-side, each with five stacked sections (General, Regen, Chillers,
 Flashlamps, Modbox).

--- a/frontend/src/components/hmi/connector-line/README.md
+++ b/frontend/src/components/hmi/connector-line/README.md
@@ -1,5 +1,7 @@
 # ConnectorLine Component
 
+> Architecture context: [`docs/frontend/hmi-components.md`](../../../../../docs/frontend/hmi-components.md). Compound-component pattern recorded in [ADR-0003](../../../../../docs/adr/0003-compound-components-for-hmi-panels.md).
+
 A refactored compound component for displaying connector lines with valves, gates, and labels.
 
 ## Improvements

--- a/frontend/src/components/hmi/controls/README.md
+++ b/frontend/src/components/hmi/controls/README.md
@@ -1,5 +1,7 @@
 # controls/
 
+> Architecture context: [`docs/frontend/hmi-components.md`](../../../../../docs/frontend/hmi-components.md). The single-write-endpoint pattern these controls consume is in [ADR-0004](../../../../../docs/adr/0004-single-pv-write-endpoint.md).
+
 Reusable HMI primitives shared by `LaserPanel` and any future control page.
 None of these are L4-specific by themselves — they hide common patterns
 (layout, write lifecycle, expand-detail) so domain panels stay declarative.

--- a/frontend/src/components/hmi/laser-panel/README.md
+++ b/frontend/src/components/hmi/laser-panel/README.md
@@ -1,5 +1,7 @@
 # LaserPanel Component
 
+> Architecture context: [`docs/frontend/hmi-components.md`](../../../../../docs/frontend/hmi-components.md). The compound-component pattern is recorded in [ADR-0003](../../../../../docs/adr/0003-compound-components-for-hmi-panels.md).
+
 Compound component for a single laser column on the `/l4-opcpa` page. Mirrors
 the `VolumePanel` idiom (compound parent + static-property section
 subcomponents) but adapted to the laser-control domain: each laser column has

--- a/frontend/src/components/hmi/volume-panel/README.md
+++ b/frontend/src/components/hmi/volume-panel/README.md
@@ -1,5 +1,7 @@
 # VolumePanel Component
 
+> Architecture context: [`docs/frontend/hmi-components.md`](../../../../../docs/frontend/hmi-components.md). Compound-component pattern recorded in [ADR-0003](../../../../../docs/adr/0003-compound-components-for-hmi-panels.md).
+
 A refactored compound component for displaying volume panels with sensors, controls, and status information.
 
 ## Recent Refactoring (June 2025)

--- a/frontend/src/lib/modules/README.md
+++ b/frontend/src/lib/modules/README.md
@@ -1,5 +1,7 @@
 # Module configs
 
+> Architecture context: [`docs/frontend/module-pages.md`](../../../../docs/frontend/module-pages.md). End-to-end recipe: [`docs/workflows/adding-a-control-page.md`](../../../../docs/workflows/adding-a-control-page.md).
+
 Each entry in this folder describes a single control module (L3BT, L4fBT, P3, ...) as a typed `ModuleConfig` (`./types.ts`). The shared `<ModuleControlPage>` (`@/components/module-page/module-control-page`) renders the config plus a bespoke `bottomRow` slot for volumes and connectors.
 
 ## Adding a new module

--- a/scripts/docs/check-index.js
+++ b/scripts/docs/check-index.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Fails if any .md under docs/ is not referenced from docs/README.md.
+// Excludes docs/README.md itself.
+const fs = require('node:fs')
+const path = require('node:path')
+
+const docsDir = path.resolve(__dirname, '..', '..', 'docs')
+const indexPath = path.join(docsDir, 'README.md')
+
+function walkMd(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) walkMd(full, acc)
+    else if (entry.isFile() && entry.name.endsWith('.md')) acc.push(full)
+  }
+  return acc
+}
+
+if (!fs.existsSync(indexPath)) {
+  console.error(`docs/README.md not found at ${indexPath}`)
+  process.exit(1)
+}
+
+const indexText = fs.readFileSync(indexPath, 'utf8')
+const allMd = walkMd(docsDir).filter((p) => p !== indexPath)
+
+const missing = []
+for (const file of allMd) {
+  const rel = path.relative(docsDir, file).split(path.sep).join('/')
+  // Accept either "./rel" or "rel" forms in the index.
+  const patterns = [`(${rel})`, `(./${rel})`]
+  if (!patterns.some((p) => indexText.includes(p))) missing.push(rel)
+}
+
+if (missing.length) {
+  console.error('docs/README.md is missing index entries for:')
+  for (const m of missing) console.error(`  - ${m}`)
+  process.exit(1)
+}
+
+console.log(`check-index: OK (${allMd.length} files indexed)`)

--- a/scripts/docs/check-links.js
+++ b/scripts/docs/check-links.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Fails on dangling relative .md links inside docs/.
+// Skips http(s)://, mailto:, and anchor-only (#...) links.
+const fs = require('node:fs')
+const path = require('node:path')
+
+const docsDir = path.resolve(__dirname, '..', '..', 'docs')
+
+function walkMd(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) walkMd(full, acc)
+    else if (entry.isFile() && entry.name.endsWith('.md')) acc.push(full)
+  }
+  return acc
+}
+
+if (!fs.existsSync(docsDir)) {
+  console.error(`docs/ not found at ${docsDir}`)
+  process.exit(1)
+}
+
+const linkRe = /\[[^\]]*\]\(([^)]+)\)/g
+const broken = []
+
+for (const file of walkMd(docsDir)) {
+  const text = fs.readFileSync(file, 'utf8')
+  let m
+  while ((m = linkRe.exec(text)) !== null) {
+    let target = m[1].trim()
+    if (!target) continue
+    if (/^(https?:|mailto:|#)/i.test(target)) continue
+    // Strip anchor and query.
+    target = target.split('#')[0].split('?')[0]
+    if (!target) continue
+    // Only check links to in-repo .md files; ignore images, dirs, etc.
+    if (!target.endsWith('.md')) continue
+    const resolved = path.resolve(path.dirname(file), target)
+    if (!fs.existsSync(resolved)) {
+      broken.push({
+        from: path.relative(docsDir, file).split(path.sep).join('/'),
+        to: target,
+      })
+    }
+  }
+}
+
+if (broken.length) {
+  console.error('Broken internal links:')
+  for (const b of broken) console.error(`  ${b.from} → ${b.to}`)
+  process.exit(1)
+}
+
+console.log('check-links: OK')

--- a/scripts/docs/sync-to-wiki.js
+++ b/scripts/docs/sync-to-wiki.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Sync docs/ to a checked-out GitHub Wiki working tree.
+//
+// Usage: node scripts/docs/sync-to-wiki.js <docs-dir> <wiki-dir>
+//
+// Rules:
+//   - docs/README.md → wiki/Home.md
+//   - docs/<sub>/<file>.md → wiki/<sub>-<file>.md  (flattened with dir prefix)
+//   - Relative .md links rewritten:
+//       ./adr/0005-x.md   → [[adr-0005-x]]
+//       ../frontend/zones.md (read from inside docs/adr/, resolves to docs/frontend/zones.md)
+//                         → [[frontend-zones]]
+//   - http(s)://, mailto:, anchor-only links pass through unchanged
+//   - Cross-tree relative links (e.g. ../../frontend/AGENTS.md) are left as-is — wiki readers
+//     who click them will see a 404; that's the deliberate boundary
+//   - Files under wiki/ that no longer have a counterpart in docs/ are deleted
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const [docsDir, wikiDir] = process.argv.slice(2)
+if (!docsDir || !wikiDir) {
+  console.error('Usage: sync-to-wiki.js <docs-dir> <wiki-dir>')
+  process.exit(2)
+}
+
+const absDocs = path.resolve(docsDir)
+const absWiki = path.resolve(wikiDir)
+
+if (!fs.existsSync(absDocs)) {
+  console.error(`docs dir not found: ${absDocs}`)
+  process.exit(1)
+}
+if (!fs.existsSync(absWiki)) {
+  console.error(`wiki dir not found: ${absWiki}`)
+  process.exit(1)
+}
+
+function walkMd(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) walkMd(full, acc)
+    else if (entry.isFile() && entry.name.endsWith('.md')) acc.push(full)
+  }
+  return acc
+}
+
+// docs/<sub>/<file>.md → "<sub>-<file>" (no .md extension, wiki convention)
+function wikiSlug(absPath) {
+  const rel = path.relative(absDocs, absPath).split(path.sep).join('/')
+  if (rel === 'README.md') return 'Home'
+  return rel.replace(/\.md$/, '').replace(/\//g, '-')
+}
+
+function rewriteLink(target, fromFileAbs) {
+  // Pass-through cases
+  if (/^(https?:|mailto:|#)/i.test(target)) return target
+  const anchorIdx = target.indexOf('#')
+  const anchor = anchorIdx === -1 ? '' : target.slice(anchorIdx)
+  const pathOnly = anchorIdx === -1 ? target : target.slice(0, anchorIdx)
+  if (!pathOnly.endsWith('.md')) return target
+
+  const resolved = path.resolve(path.dirname(fromFileAbs), pathOnly)
+  // If the link points outside docs/, leave it as-is.
+  if (!resolved.startsWith(absDocs + path.sep) && resolved !== absDocs) {
+    return target
+  }
+  if (!fs.existsSync(resolved)) return target // dangling — caught by check-links
+  const slug = wikiSlug(resolved)
+  return `[[${slug}${anchor}]]`
+}
+
+const linkRe = /(\[[^\]]*\])\(([^)]+)\)/g
+
+function rewriteContent(text, fromFileAbs) {
+  return text.replace(linkRe, (_match, label, target) => {
+    const next = rewriteLink(target.trim(), fromFileAbs)
+    if (next.startsWith('[[')) return next // wiki link drops the label form
+    return `${label}(${next})`
+  })
+}
+
+// 1. Write/overwrite the canonical set of wiki pages.
+const docFiles = walkMd(absDocs)
+const expectedWikiNames = new Set()
+
+for (const file of docFiles) {
+  const slug = wikiSlug(file)
+  const out = path.join(absWiki, `${slug}.md`)
+  expectedWikiNames.add(`${slug}.md`)
+  const text = fs.readFileSync(file, 'utf8')
+  const rewritten = rewriteContent(text, file)
+  fs.writeFileSync(out, rewritten, 'utf8')
+}
+
+// 2. Delete wiki .md files that no longer have a counterpart in docs/.
+//    Preserve dotfiles and non-.md files.
+for (const entry of fs.readdirSync(absWiki, { withFileTypes: true })) {
+  if (!entry.isFile()) continue
+  if (entry.name.startsWith('.')) continue
+  if (!entry.name.endsWith('.md')) continue
+  if (expectedWikiNames.has(entry.name)) continue
+  fs.unlinkSync(path.join(absWiki, entry.name))
+  console.log(`deleted stale: ${entry.name}`)
+}
+
+console.log(`synced ${docFiles.length} pages to ${absWiki}`)


### PR DESCRIPTION
Closes #34.

## Summary

- `/docs/` tree mapping the whole stack (frontend + Go mock + Python FastAPI), 36 pages: architecture / glossary / context backbone, 7 frontend pages, 5 backend pages, reference, 5 runbooks, 4 workflows, 9 ADRs + template.
- Vocabulary follows `.agents/skills/improve-codebase-architecture/LANGUAGE.md` exactly (module / interface / seam / adapter / depth / leverage / locality).
- Zero-dep Node check scripts (`scripts/docs/check-{index,links}.js`) gating on a new GitLab CI `docs-validate` job.
- Custom GitHub Action (`.github/workflows/sync-docs-to-wiki.yml`) mirrors `docs/` → GitHub Wiki on push to `dev`: flattens subdirs (`docs/adr/0005-x.md` → `wiki/adr-0005-x.md`), rewrites in-tree relative links to wiki-link syntax (`[[adr-0005-x]]`), deletes stale pages, idempotent.
- Cross-links existing READMEs (root AGENTS + 8 module READMEs across frontend + backend) upward to the matching `docs/` page.

## Things surfaced honestly (not papered over)

- Code uses `NEXT_PUBLIC_API_URL`, not `NEXT_PUBLIC_WEBSOCKET_URL` (which older AGENTS.md text claimed). Documented in `docs/reference/env-vars.md`.
- The mock and Python WS adapters do **not** satisfy the same frame contract today. Detailed in `docs/backend/websocket-protocol.md`; named as architectural debt in `ADR-0009 (Open)` with three resolution paths.
- Python server is read/monitor only — `POST /pv/<NAME>` is mock-only. Recorded in `docs/backend/pv-write-endpoint.md` and `ADR-0004`.
- Two pre-existing call sites bypass `pvWrite()` (`WarningErrorControl.tsx`, `DropDownStateControl.tsx`) — flagged in `docs/context.md` as a deepening target.

## Test plan

- [x] `node scripts/docs/check-index.js` — exits 0 (36 files indexed)
- [x] `node scripts/docs/check-links.js` — exits 0 (no dangling internal links)
- [x] `node scripts/docs/sync-to-wiki.js docs /tmp/eli-hmi-wiki-test` smoke-tested: README→Home, subdirs flattened with prefix, in-tree links rewritten, external links preserved, stale page deleted
- [ ] Verify the GitHub Action runs on first `docs/**` push to `dev` (requires merge to `dev`; concurrency group `wiki-sync`, `contents: write` permission, default `GITHUB_TOKEN`)
- [ ] Verify the wiki Home + a sample sub-page render with working internal `[[wiki-link]]` navigation
- [ ] Render `docs/README.md` in a Markdown viewer — every link resolves
- [ ] Walk a fresh contributor through `docs/runbooks/local-dev.md` end-to-end

## Open follow-ups (deliberately not in this PR)

- ADR-0009 is **Open**. Picking option 1/2/3 there is the next architectural decision, not a docs task.
- `frontend/AGENTS.md` still says `NEXT_PUBLIC_WEBSOCKET_URL` in one place. The reference doc corrects this; the AGENTS.md can be updated in a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)