### PR TITLE
Align NL2 L4 OPCPA panel with current wireframe

### DIFF
--- a/frontend/src/app/(modules)/l4-opcpa/components/laser-panel-instance.test.tsx
+++ b/frontend/src/app/(modules)/l4-opcpa/components/laser-panel-instance.test.tsx
@@ -70,13 +70,14 @@ describe('LaserPanelInstance', () => {
   it('renders the column header and one representative row per section', () => {
     renderSpec(NL2)
     expect(screen.getByRole('heading', { name: 'NL2' })).toBeInTheDocument()
+    expect(screen.getByText('Sequencer')).toBeInTheDocument()
     expect(screen.getByText('Overview')).toBeInTheDocument()
     expect(screen.getByText('Shutter Position')).toBeInTheDocument()
     expect(screen.getByText('Regen SY3PL50M:32')).toBeInTheDocument()
     expect(screen.getByText('Chiller PS1225:11')).toBeInTheDocument()
     expect(screen.getByText('Flashlamps State')).toBeInTheDocument()
     expect(screen.getByText('Modbox State')).toBeInTheDocument()
-    expect(screen.getByText('Loaded Waveform')).toBeInTheDocument()
+    expect(screen.getByText('Waveform Latest')).toBeInTheDocument()
   })
 
   it('hides sections whose device bank is empty', () => {

--- a/frontend/src/app/(modules)/l4-opcpa/components/laser-panel-instance.tsx
+++ b/frontend/src/app/(modules)/l4-opcpa/components/laser-panel-instance.tsx
@@ -17,6 +17,10 @@ interface LaserPanelInstanceProps {
  */
 export const LaserPanelInstance: FC<LaserPanelInstanceProps> = ({ spec }) => (
   <LaserPanel title={spec.laser}>
+    <LaserPanel.Sequencer
+      sequencerPv={spec.sequencer}
+      sequences={spec.sequences}
+    />
     <LaserPanel.General
       laser={spec.laser}
       connectionPv={spec.pvs.connection}
@@ -50,6 +54,9 @@ export const LaserPanelInstance: FC<LaserPanelInstanceProps> = ({ spec }) => (
         laser={spec.laser}
         modbox={spec.modbox}
         loadedWaveformPv={spec.pvs.loadedWaveform}
+        mbc1Pv={spec.pvs.mbc1}
+        mbc2Pv={spec.pvs.mbc2}
+        waveformPresetPv={spec.pvs.waveformPreset}
         commands={spec.commands}
       />
     )}

--- a/frontend/src/app/(modules)/l4-opcpa/config/lasers.schema.json
+++ b/frontend/src/app/(modules)/l4-opcpa/config/lasers.schema.json
@@ -60,6 +60,21 @@
                 "type": "string",
                 "minLength": 1,
                 "description": "Currently loaded waveform name."
+              },
+              "mbc1": {
+                "description": "Modbox State MBC1 float readout. Optional — absent → shown as unknown (<>).",
+                "type": "string",
+                "minLength": 1
+              },
+              "mbc2": {
+                "description": "Modbox State MBC2 float readout. Optional — absent → shown as unknown (<>).",
+                "type": "string",
+                "minLength": 1
+              },
+              "waveformPreset": {
+                "description": "Preset (next-launch) waveform name. Optional — absent → shown as unknown (<>).",
+                "type": "string",
+                "minLength": 1
               }
             },
             "required": [
@@ -75,6 +90,35 @@
             ],
             "additionalProperties": false,
             "description": "Single-signal read/write PVs."
+          },
+          "sequencer": {
+            "description": "Sequencer state bool (1 = RUNNING, 0 = IDLE). Optional — absent → shown as unknown (<>).",
+            "type": "string",
+            "minLength": 1
+          },
+          "sequences": {
+            "description": "Per-sequence state indicators for the expanded Sequencer list. Optional — absent/empty → the Sequencer row is not expandable.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Display label shown in the UI."
+                },
+                "pv": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Full EPICS PV name (from controls)."
+                }
+              },
+              "required": [
+                "label",
+                "pv"
+              ],
+              "additionalProperties": false
+            }
           },
           "triggerDelay": {
             "minItems": 1,

--- a/frontend/src/app/(modules)/l4-opcpa/config/schema.test.ts
+++ b/frontend/src/app/(modules)/l4-opcpa/config/schema.test.ts
@@ -120,6 +120,14 @@ describe('parseLaserSpecs', () => {
     ).toThrow(/duplicate PV name/)
   })
 
+  it('still flags a duplicate when an optional pvs field collides with another PV', () => {
+    expect(() =>
+      parseLaserSpecs(
+        doc([laser({ pvs: { ...laser().pvs, mbc1: 'BI_NL9_CONN' } })]),
+      ),
+    ).toThrow(/duplicate PV name/)
+  })
+
   it('rejects unknown commands', () => {
     expect(() =>
       parseLaserSpecs(doc([laser({ commands: ['NOT_A_COMMAND'] })])),

--- a/frontend/src/app/(modules)/l4-opcpa/config/schema.ts
+++ b/frontend/src/app/(modules)/l4-opcpa/config/schema.ts
@@ -124,7 +124,7 @@ export const rawLaserSchema = z.strictObject({
     ...laser.modbox,
     ...(laser.sequencer ? [laser.sequencer] : []),
     ...(laser.sequences?.map((s) => s.pv) ?? []),
-  ]
+  ].filter((name): name is string => typeof name === 'string')
   const seen = new Set<string>()
   const dupes = new Set<string>()
   for (const name of all) {

--- a/frontend/src/app/(modules)/l4-opcpa/config/schema.ts
+++ b/frontend/src/app/(modules)/l4-opcpa/config/schema.ts
@@ -53,8 +53,34 @@ export const rawLaserSchema = z.strictObject({
       phd2Mean: pvName.describe('Second PHD mean readout.'),
       attenuator: pvName.describe('Attenuator value (read + direct write).'),
       loadedWaveform: pvName.describe('Currently loaded waveform name.'),
+      mbc1: pvName
+        .optional()
+        .describe(
+          'Modbox State MBC1 float readout. Optional — absent → shown as unknown (<>).',
+        ),
+      mbc2: pvName
+        .optional()
+        .describe(
+          'Modbox State MBC2 float readout. Optional — absent → shown as unknown (<>).',
+        ),
+      waveformPreset: pvName
+        .optional()
+        .describe(
+          'Preset (next-launch) waveform name. Optional — absent → shown as unknown (<>).',
+        ),
     })
     .describe('Single-signal read/write PVs.'),
+  sequencer: pvName
+    .optional()
+    .describe(
+      'Sequencer state bool (1 = RUNNING, 0 = IDLE). Optional — absent → shown as unknown (<>).',
+    ),
+  sequences: z
+    .array(labeledPv)
+    .optional()
+    .describe(
+      'Per-sequence state indicators for the expanded Sequencer list. Optional — absent/empty → the Sequencer row is not expandable.',
+    ),
   triggerDelay: z
     .array(pvName)
     .min(1)
@@ -96,6 +122,8 @@ export const rawLaserSchema = z.strictObject({
     ...laser.chillers.flatMap((c) => [c.flow, c.temp, c.level]),
     ...laser.flashlamps.map((f) => f.pv),
     ...laser.modbox,
+    ...(laser.sequencer ? [laser.sequencer] : []),
+    ...(laser.sequences?.map((s) => s.pv) ?? []),
   ]
   const seen = new Set<string>()
   const dupes = new Set<string>()

--- a/frontend/src/app/(modules)/l4-opcpa/page.tsx
+++ b/frontend/src/app/(modules)/l4-opcpa/page.tsx
@@ -8,6 +8,9 @@ import { L4OpcpaView } from './components/l4-opcpa-view'
  * validation happens at `next build`; an invalid config fails the build.
  */
 export default function L4OpcpaPage() {
-  const specs = loadLaserSpecs()
+  // The GUI will eventually cover APL + NL1–5, but the current rollout targets
+  // NL2 only. The other lasers stay in lasers.yaml (ready to re-enable) — we
+  // just don't render them yet.
+  const specs = loadLaserSpecs().filter((spec) => spec.laser === 'NL2')
   return <L4OpcpaView specs={specs} />
 }

--- a/frontend/src/components/hmi/controls/CogToggle.module.css
+++ b/frontend/src/components/hmi/controls/CogToggle.module.css
@@ -38,7 +38,10 @@
 .panel {
   position: absolute;
   top: calc(100% + 0.25rem);
-  right: 0;
+  /* Open left-aligned to the cog so the panel grows rightward into the page's
+     empty space, never leftward under the sidebar/content boundary. The JS
+     clamp only nudges it back from the right viewport edge if it overflows. */
+  left: 0;
   z-index: 5;
   background: var(--color-surface-light);
   border: 1px solid var(--color-text);
@@ -47,5 +50,6 @@
   flex-direction: column;
   gap: 0.375rem;
   min-width: 14rem;
+  max-width: calc(100vw - 1rem);
   box-shadow: var(--shadow-md);
 }

--- a/frontend/src/components/hmi/controls/CogToggle.tsx
+++ b/frontend/src/components/hmi/controls/CogToggle.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react'
@@ -45,8 +46,40 @@ export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
 }) => {
   const [open, setOpen] = useState(false)
   const wrapperRef = useRef<HTMLSpanElement | null>(null)
+  const panelRef = useRef<HTMLDivElement | null>(null)
+  // Horizontal nudge (px) applied to keep the panel on-screen. The panel is
+  // left-anchored (opens rightward from the cog into the page's empty space),
+  // so it can only overflow the *right* viewport edge — never the left, where
+  // the sidebar/content boundary lives. We measure after open and, if it spills
+  // past the right edge, shift it back into the viewport.
+  const [shiftX, setShiftX] = useState(0)
 
   const close = useCallback(() => setOpen(false), [])
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setShiftX(0)
+      return
+    }
+    const panel = panelRef.current
+    if (!panel) return
+    const margin = 8
+    // Measure the panel's natural (unshifted) edges by clearing any applied
+    // transform first; reading getBoundingClientRect forces the reflow. This
+    // keeps the effect convergent regardless of whether the transform is
+    // reflected back in the measured rect.
+    const applied = panel.style.transform
+    panel.style.transform = ''
+    const rect = panel.getBoundingClientRect()
+    panel.style.transform = applied
+    let next = 0
+    if (rect.right > window.innerWidth - margin) {
+      next = window.innerWidth - margin - rect.right
+      // Never pull the left edge off the left viewport edge while fixing right.
+      if (rect.left + next < margin) next = margin - rect.left
+    }
+    setShiftX((cur) => (cur === next ? cur : next))
+  }, [open, shiftX])
 
   useEffect(() => {
     if (!open) return
@@ -87,7 +120,13 @@ export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
       </button>
       {open ? (
         <CogToggleContext.Provider value={close}>
-          <div className={styles.panel}>{children}</div>
+          <div
+            ref={panelRef}
+            className={styles.panel}
+            style={shiftX ? { transform: `translateX(${shiftX}px)` } : undefined}
+          >
+            {children}
+          </div>
         </CogToggleContext.Provider>
       ) : null}
     </span>

--- a/frontend/src/components/hmi/controls/DetailList.module.css
+++ b/frontend/src/components/hmi/controls/DetailList.module.css
@@ -16,7 +16,6 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.125rem 0.5rem;
-  border-left: 3px solid transparent;
   min-width: 0;
 }
 
@@ -35,69 +34,43 @@
   letter-spacing: 0.04em;
   flex-shrink: 0;
   padding-left: 0.5rem;
+  color: var(--color-text);
 }
 
-.dot {
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  background: var(--color-text-secondary);
+.item[data-state='ok'] .trailing {
+  color: var(--color-success-dark);
 }
 
-.item[data-state='ok'] {
-  border-left-color: var(--color-success-dark);
-}
-.item[data-state='ok'] .dot {
-  background: var(--color-success-dark);
-}
-
-.item[data-state='err'] {
-  border-left-color: var(--color-error-dark);
-  font-weight: 700;
-}
-.item[data-state='err'] .dot {
-  background: var(--color-error-dark);
-}
 .item[data-state='err'] .trailing {
   color: var(--color-error-dark);
 }
 
-.item[data-state='run'] {
-  border-left-color: var(--color-success-dark);
-}
 .item[data-state='run'] .trailing {
   color: var(--color-success-dark);
 }
 
-.item[data-state='sb'] {
-  border-left-color: var(--color-gray-800);
-}
 .item[data-state='sb'] .trailing {
   color: var(--color-gray-800);
 }
 
-.item[data-state='stop'] {
-  border-left-color: var(--color-warning-dark);
-}
 .item[data-state='stop'] .trailing {
   color: var(--color-warning-dark);
 }
 
-.item[data-state='fail'] {
-  border-left-color: var(--color-error-dark);
-  font-weight: 700;
-}
 .item[data-state='fail'] .trailing {
   color: var(--color-error-dark);
   text-decoration: underline double;
 }
 
-.item[data-state='unknown'] {
-  border-left-style: dotted;
-  border-left-color: var(--color-gray-800);
+.item[data-state='unknown'] .trailing {
   color: var(--color-gray-800);
 }
-.item[data-state='unknown'] .dot {
-  background: transparent;
-  border: 1px dotted currentColor;
+
+.note {
+  margin: 0.25rem 0 0;
+  padding: 0 0.5rem;
+  font-size: 0.6875rem;
+  font-style: italic;
+  line-height: 1.3;
+  color: var(--color-text-secondary);
 }

--- a/frontend/src/components/hmi/controls/DetailList.test.tsx
+++ b/frontend/src/components/hmi/controls/DetailList.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DetailList } from './DetailList'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('DetailList', () => {
+  it('renders rows with duplicate labels without a React key collision', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <DetailList
+        items={[
+          { label: 'Ch1', state: 'ok' },
+          { label: 'Ch1', state: 'err' },
+        ]}
+      />,
+    )
+
+    // Both duplicate-label rows render.
+    expect(screen.getAllByText('Ch1')).toHaveLength(2)
+
+    // React did not warn about a duplicate key.
+    const warnedDuplicateKey = errSpy.mock.calls.some(
+      (call) => typeof call[0] === 'string' && call[0].includes('same key'),
+    )
+    expect(warnedDuplicateKey).toBe(false)
+  })
+})

--- a/frontend/src/components/hmi/controls/DetailList.tsx
+++ b/frontend/src/components/hmi/controls/DetailList.tsx
@@ -52,9 +52,9 @@ export const DetailList: FC<DetailListProps> = ({ items, note }) => {
   return (
     <>
       <ul className={styles.list}>
-        {items.map((item) => (
+        {items.map((item, i) => (
           <li
-            key={item.label}
+            key={`${item.label}-${i}`}
             className={styles.item}
             data-state={item.state}
           >

--- a/frontend/src/components/hmi/controls/DetailList.tsx
+++ b/frontend/src/components/hmi/controls/DetailList.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 import styles from './DetailList.module.css'
 
 /**
@@ -17,37 +17,55 @@ export type DetailListItemState =
 export interface DetailListItem {
   /** Display label (e.g. "MSS 1", "REGEN", "22 Ch1"). */
   label: string
-  /** Tone driving the per-item border + dot. */
+  /** Tone driving the trailing status text colour. */
   state: DetailListItemState
-  /** Optional text shown on the right (e.g. the literal state string). */
+  /** Optional text shown on the right. Falls back to a readable per-state
+   * default so every row carries a text label, not just colour. */
   trailing?: string
 }
 
 interface DetailListProps {
   items: DetailListItem[]
+  /** Optional compact footnote under the list (e.g. "selected, not
+   * exhaustive"). Rendered in muted HMI styling. */
+  note?: ReactNode
+}
+
+/** Readable fallback word per state, so a row is never colour-only. */
+const DEFAULT_TRAILING: Record<DetailListItemState, string> = {
+  ok: 'OK',
+  err: 'ERR',
+  run: 'RUN',
+  sb: 'SB',
+  stop: 'STOP',
+  fail: 'FAIL',
+  unknown: 'N/A',
 }
 
 /**
  * Expanded-detail list used by the four merged indicators in the wireframe:
- * MSS, Module Errors, Modbox State, and Flashlamps State. Each item has a
- * state tag that drives a left border + optional dot, so the operator can
- * spot the outliers at a glance.
+ * MSS, Module Errors, Modbox State, and Flashlamps State. Each row carries a
+ * single status indicator — a readable, colour-coded text label on the right —
+ * so the operator never depends on colour alone.
  */
-export const DetailList: FC<DetailListProps> = ({ items }) => {
+export const DetailList: FC<DetailListProps> = ({ items, note }) => {
   return (
-    <ul className={styles.list}>
-      {items.map((item) => (
-        <li
-          key={item.label}
-          className={styles.item}
-          data-state={item.state}
-        >
-          <span className={styles.label}>{item.label}</span>
-          <span className={styles.trailing}>
-            {item.trailing ?? <span className={styles.dot} aria-hidden />}
-          </span>
-        </li>
-      ))}
-    </ul>
+    <>
+      <ul className={styles.list}>
+        {items.map((item) => (
+          <li
+            key={item.label}
+            className={styles.item}
+            data-state={item.state}
+          >
+            <span className={styles.label}>{item.label}</span>
+            <span className={styles.trailing}>
+              {item.trailing ?? DEFAULT_TRAILING[item.state]}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {note && <p className={styles.note}>{note}</p>}
+    </>
   )
 }

--- a/frontend/src/components/hmi/controls/PresetIntegerInput.module.css
+++ b/frontend/src/components/hmi/controls/PresetIntegerInput.module.css
@@ -31,15 +31,13 @@
   font-variant-numeric: tabular-nums;
 }
 
-.chip:hover {
+.chip:hover:not(:disabled) {
   background: var(--color-surface);
 }
 
-/* Staged chip: green tint + green border. */
-.chip[data-staged='true'] {
-  border-color: var(--color-success-dark);
-  color: var(--color-success-dark);
-  background: color-mix(in srgb, var(--color-success) 22%, var(--color-surface-lighter));
+.chip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .customRow {
@@ -71,14 +69,8 @@
   color: var(--color-text);
 }
 
-.actions {
-  display: grid;
-  grid-template-columns: 1fr 2fr;
-  gap: 0.25rem;
-}
-
-.cancel,
 .confirm {
+  flex-shrink: 0;
   font: inherit;
   font-size: 0.75rem;
   font-weight: 700;
@@ -92,12 +84,10 @@
   cursor: pointer;
 }
 
-.cancel:hover:not(:disabled),
 .confirm:hover:not(:disabled) {
   background: var(--color-surface);
 }
 
-.cancel:disabled,
 .confirm:disabled {
   opacity: 0.55;
   cursor: not-allowed;

--- a/frontend/src/components/hmi/controls/PresetIntegerInput.test.tsx
+++ b/frontend/src/components/hmi/controls/PresetIntegerInput.test.tsx
@@ -34,25 +34,7 @@ describe('PresetIntegerInput', () => {
     expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled()
   })
 
-  it('stages a preset value on chip click and enables Confirm', async () => {
-    const user = userEvent.setup()
-    renderInput()
-    await user.click(screen.getByRole('button', { name: '790' }))
-    const confirm = screen.getByRole('button', { name: /Confirm/ })
-    expect(confirm).not.toBeDisabled()
-    expect(confirm).toHaveTextContent('790')
-  })
-
-  it('stages a custom value from the integer input field', async () => {
-    const user = userEvent.setup()
-    renderInput()
-    await user.type(screen.getByLabelText(/custom/i), '650')
-    const confirm = screen.getByRole('button', { name: /Confirm/ })
-    expect(confirm).not.toBeDisabled()
-    expect(confirm).toHaveTextContent('650')
-  })
-
-  it('POSTs to /pv/<pvName> with the staged value when Confirm is clicked', async () => {
+  it('applies a preset immediately on chip click (no Confirm step)', async () => {
     const spy = vi.fn<typeof fetch>(
       async () =>
         new Response(JSON.stringify({ ok: true }), { status: 200 }),
@@ -61,7 +43,34 @@ describe('PresetIntegerInput', () => {
     const user = userEvent.setup()
     renderInput()
 
-    await user.click(screen.getByRole('button', { name: '500' }))
+    await user.click(screen.getByRole('button', { name: '790' }))
+
+    await waitFor(() => expect(spy).toHaveBeenCalled())
+    expect(spy.mock.calls[0][0]).toBe(
+      'http://localhost:8080/pv/CMD_NL2_SET_DELAY',
+    )
+    const init = spy.mock.calls[0][1] as RequestInit
+    expect(JSON.parse(init.body as string)).toEqual({ value: 790 })
+  })
+
+  it('stages a custom value from the integer input field and enables Confirm', async () => {
+    const user = userEvent.setup()
+    renderInput()
+    expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled()
+    await user.type(screen.getByLabelText(/custom/i), '650')
+    expect(screen.getByRole('button', { name: /Confirm/ })).not.toBeDisabled()
+  })
+
+  it('POSTs the custom value to /pv/<pvName> when Confirm is clicked', async () => {
+    const spy = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+    globalThis.fetch = spy as unknown as typeof fetch
+    const user = userEvent.setup()
+    renderInput()
+
+    await user.type(screen.getByLabelText(/custom/i), '650')
     await user.click(screen.getByRole('button', { name: /Confirm/ }))
 
     await waitFor(() => expect(spy).toHaveBeenCalled())
@@ -69,15 +78,7 @@ describe('PresetIntegerInput', () => {
       'http://localhost:8080/pv/CMD_NL2_SET_DELAY',
     )
     const init = spy.mock.calls[0][1] as RequestInit
-    expect(JSON.parse(init.body as string)).toEqual({ value: 500 })
-  })
-
-  it('Cancel clears the staged value and disables Confirm again', async () => {
-    const user = userEvent.setup()
-    renderInput()
-    await user.click(screen.getByRole('button', { name: '790' }))
-    await user.click(screen.getByRole('button', { name: /Cancel/ }))
-    expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled()
+    expect(JSON.parse(init.body as string)).toEqual({ value: 650 })
   })
 
   it('disables Confirm when the staged value is out of range', async () => {

--- a/frontend/src/components/hmi/controls/PresetIntegerInput.test.tsx
+++ b/frontend/src/components/hmi/controls/PresetIntegerInput.test.tsx
@@ -126,4 +126,28 @@ describe('PresetIntegerInput', () => {
     expect(screen.queryByText(/out of range/i)).not.toBeInTheDocument()
     expect(screen.getByLabelText(/custom/i)).toHaveValue(null)
   })
+
+  it('does not POST when an out-of-range preset is clicked', async () => {
+    const spy = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+    globalThis.fetch = spy as unknown as typeof fetch
+    const user = userEvent.setup()
+    render(
+      <PresetIntegerInput
+        label="Trigger Delay"
+        presets={[50, 500, 700, 790]}
+        pvName="CMD_NL2_SET_DELAY"
+        min={0}
+        max={600}
+      />,
+    )
+
+    // 790 exceeds max=600 → guarded: no write, range error surfaced.
+    await user.click(screen.getByRole('button', { name: '790' }))
+
+    expect(screen.getByText(/out of range/i)).toBeInTheDocument()
+    expect(spy).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/components/hmi/controls/PresetIntegerInput.test.tsx
+++ b/frontend/src/components/hmi/controls/PresetIntegerInput.test.tsx
@@ -96,4 +96,34 @@ describe('PresetIntegerInput', () => {
     expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled()
     expect(screen.getByText(/out of range/i)).toBeInTheDocument()
   })
+
+  it('clears a stale custom value and validation error when a preset is clicked', async () => {
+    // A never-resolving write keeps the write 'pending', so the success-effect
+    // cleanup cannot fire — isolating the on-click cleanup as the only thing
+    // that can clear the stale custom input.
+    globalThis.fetch = vi.fn(
+      () => new Promise<Response>(() => {}),
+    ) as unknown as typeof fetch
+    const user = userEvent.setup()
+    render(
+      <PresetIntegerInput
+        label="Trigger Delay"
+        presets={[50, 500, 700, 790]}
+        pvName="CMD_NL2_SET_DELAY"
+        min={0}
+        max={1000}
+      />,
+    )
+
+    // Stage an out-of-range custom value → validation error + retained value.
+    await user.type(screen.getByLabelText(/custom/i), '-5')
+    expect(screen.getByText(/out of range/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/custom/i)).toHaveValue(-5)
+
+    // Clicking a preset applies immediately and wipes the stale custom state.
+    await user.click(screen.getByRole('button', { name: '500' }))
+
+    expect(screen.queryByText(/out of range/i)).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/custom/i)).toHaveValue(null)
+  })
 })

--- a/frontend/src/components/hmi/controls/PresetIntegerInput.tsx
+++ b/frontend/src/components/hmi/controls/PresetIntegerInput.tsx
@@ -82,6 +82,11 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
   const onPresetClick = useCallback(
     (value: number) => {
       if (pending) return
+      // Presets apply immediately; clear any stale custom-input state first so a
+      // leftover validation error / custom value doesn't linger after the write.
+      setStaged(null)
+      setCustomText('')
+      setParseError(null)
       void write(pvName, value)
     },
     [pending, pvName, write],

--- a/frontend/src/components/hmi/controls/PresetIntegerInput.tsx
+++ b/frontend/src/components/hmi/controls/PresetIntegerInput.tsx
@@ -38,8 +38,8 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
       ? `Out of range (${min ?? '−∞'}..${max ?? '∞'})`
       : null
 
-  // Reset the staged value after a successful write (hook reports 'success'
-  // and we mirror the old reset-and-let-cog-close behaviour).
+  // Clear the custom field after a successful write (the cog closes on success
+  // anyway; this keeps it clean if the control lives outside a CogToggle).
   useEffect(() => {
     if (state === 'success') {
       setStaged(null)
@@ -77,17 +77,15 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
     setStaged(n)
   }, [])
 
-  const onChipClick = useCallback((value: number) => {
-    setStaged(value)
-    setCustomText('')
-    setParseError(null)
-  }, [])
-
-  const onCancel = useCallback(() => {
-    setStaged(null)
-    setCustomText('')
-    setParseError(null)
-  }, [])
+  // Presets apply immediately — no CONFIRM step (spec: preset buttons must
+  // apply on click). The manual custom value still goes through CONFIRM.
+  const onPresetClick = useCallback(
+    (value: number) => {
+      if (pending) return
+      void write(pvName, value)
+    },
+    [pending, pvName, write],
+  )
 
   const onConfirm = useCallback(() => {
     if (staged === null) return
@@ -108,16 +106,18 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
               key={p}
               type="button"
               className={styles.chip}
-              data-staged={staged === p}
-              onClick={() => onChipClick(p)}
+              disabled={pending}
+              onClick={() => onPresetClick(p)}
             >
               {p}
             </button>
           ))}
         </div>
       )}
-      <label className={styles.customRow} htmlFor={inputId}>
-        <span className={styles.customLabel}>Custom</span>
+      <div className={styles.customRow}>
+        <label className={styles.customLabel} htmlFor={inputId}>
+          Custom
+        </label>
         <input
           id={inputId}
           className={styles.input}
@@ -128,16 +128,6 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
           max={max}
           onChange={(e) => onCustomChange(e.target.value)}
         />
-      </label>
-      <div className={styles.actions}>
-        <button
-          type="button"
-          className={styles.cancel}
-          onClick={onCancel}
-          disabled={staged === null && customText === ''}
-        >
-          Cancel
-        </button>
         <button
           type="button"
           className={styles.confirm}
@@ -145,11 +135,7 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
           disabled={!stagedValid || pending}
           data-state={pending ? 'pending' : error ? 'error' : 'idle'}
         >
-          {staged !== null
-            ? pending
-              ? `Setting ${staged}…`
-              : `Confirm ${staged}`
-            : 'Confirm'}
+          {staged !== null && pending ? `Setting ${staged}…` : 'Confirm'}
         </button>
       </div>
       {(error || rangeError || parseError) && (

--- a/frontend/src/components/hmi/controls/PresetIntegerInput.tsx
+++ b/frontend/src/components/hmi/controls/PresetIntegerInput.tsx
@@ -82,6 +82,15 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
   const onPresetClick = useCallback(
     (value: number) => {
       if (pending) return
+      // Apply the SAME min/max guard used for custom values (onConfirm): a
+      // preset outside the allowed range must not be written.
+      const ok =
+        (min === undefined || value >= min) &&
+        (max === undefined || value <= max)
+      if (!ok) {
+        setParseError(`Out of range (${min ?? '−∞'}..${max ?? '∞'})`)
+        return
+      }
       // Presets apply immediately; clear any stale custom-input state first so a
       // leftover validation error / custom value doesn't linger after the write.
       setStaged(null)
@@ -89,7 +98,7 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
       setParseError(null)
       void write(pvName, value)
     },
-    [pending, pvName, write],
+    [pending, pvName, write, min, max],
   )
 
   const onConfirm = useCallback(() => {

--- a/frontend/src/components/hmi/controls/Values.tsx
+++ b/frontend/src/components/hmi/controls/Values.tsx
@@ -20,17 +20,22 @@ type NumMsg = Message<number | null> | undefined
 type StrMsg = Message<string | null> | undefined
 
 /** Float value (precision-formatted) + optional units chip. */
-export const FloatValue: FC<{ data: NumMsg; precision?: number }> = ({
-  data,
-  precision = 3,
-}) => {
+export const FloatValue: FC<{
+  data: NumMsg
+  precision?: number
+  /** Suppress the units chip even when the PV reports units (e.g. Regen Temp,
+   * which the wireframe shows without a unit indicator). */
+  hideUnits?: boolean
+}> = ({ data, precision = 3, hideUnits = false }) => {
   if (!data || !data.ok || typeof data.value !== 'number') {
     return <span className={styles.placeholder}>{EMPTY}</span>
   }
   return (
     <>
       <span className={styles.number}>{data.value.toFixed(precision)}</span>
-      {data.units && <span className={styles.units}>{data.units}</span>}
+      {!hideUnits && data.units && (
+        <span className={styles.units}>{data.units}</span>
+      )}
     </>
   )
 }

--- a/frontend/src/components/hmi/laser-panel/GeneralSection.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/GeneralSection.test.tsx
@@ -159,6 +159,8 @@ describe('GeneralSection', () => {
     expect(screen.getByText('MSS 1')).toBeInTheDocument()
     expect(screen.getByText('MSS 2')).toBeInTheDocument()
     expect(screen.getByText('MSS 3')).toBeInTheDocument()
+    // The list is a selected, non-exhaustive set — surfaced as a note.
+    expect(screen.getByText(/not an exhaustive list/i)).toBeInTheDocument()
   })
 
   it('expands the Module Errors detail list and labels items by error name', async () => {

--- a/frontend/src/components/hmi/laser-panel/LaserPanel.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/LaserPanel.test.tsx
@@ -16,6 +16,7 @@ describe('LaserPanel', () => {
   })
 
   it('exposes section components as static properties', () => {
+    expect(LaserPanel.Sequencer).toBeDefined()
     expect(LaserPanel.General).toBeDefined()
     expect(LaserPanel.Regen).toBeDefined()
     expect(LaserPanel.Chillers).toBeDefined()

--- a/frontend/src/components/hmi/laser-panel/LaserPanel.tsx
+++ b/frontend/src/components/hmi/laser-panel/LaserPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { FC, PropsWithChildren } from 'react'
+import { SequencerSection } from './SequencerSection'
 import { GeneralSection } from './GeneralSection'
 import { RegenSection } from './RegenSection'
 import { ChillersSection } from './ChillersSection'
@@ -21,6 +22,7 @@ interface LaserPanelProps {
  * code. `laser` is passed only where command PVs are needed.
  */
 export const LaserPanel: FC<PropsWithChildren<LaserPanelProps>> & {
+  Sequencer: typeof SequencerSection
   General: typeof GeneralSection
   Regen: typeof RegenSection
   Chillers: typeof ChillersSection
@@ -37,6 +39,7 @@ export const LaserPanel: FC<PropsWithChildren<LaserPanelProps>> & {
   )
 }
 
+LaserPanel.Sequencer = SequencerSection
 LaserPanel.General = GeneralSection
 LaserPanel.Regen = RegenSection
 LaserPanel.Chillers = ChillersSection

--- a/frontend/src/components/hmi/laser-panel/ModboxSection.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/ModboxSection.test.tsx
@@ -62,8 +62,60 @@ describe('ModboxSection', () => {
 
     expect(screen.getByText('Modbox State')).toBeInTheDocument()
     expect(screen.getByText('2 / 3')).toBeInTheDocument()
-    expect(screen.getByText('Loaded Waveform')).toBeInTheDocument()
+    expect(screen.getByText('Waveform Latest')).toBeInTheDocument()
     expect(screen.getAllByText('std-100ps').length).toBeGreaterThan(0)
+  })
+
+  it('renders the full Modbox row structure: BOOL, MBC1, MBC2, Waveform Preset, Waveform Latest, and Modbox Actions', async () => {
+    const ws = renderModbox()
+    await waitFor(() =>
+      expect(ws.subscriptions.get('BI_NL2_MODBOX_1')?.size).toBe(1),
+    )
+
+    // Merged BOOL count + the two MBC float columns from the wireframe.
+    expect(screen.getByText('Modbox State')).toBeInTheDocument()
+    expect(screen.getByText('BOOL')).toBeInTheDocument()
+    expect(screen.getByText('MBC1')).toBeInTheDocument()
+    expect(screen.getByText('MBC2')).toBeInTheDocument()
+    // Both waveform rows.
+    expect(screen.getByText('Waveform Preset')).toBeInTheDocument()
+    expect(screen.getByText('Waveform Latest')).toBeInTheDocument()
+    // Modbox actions cog.
+    expect(
+      screen.getByRole('button', { name: 'Modbox actions' }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the unknown placeholder for MBC1/MBC2/Waveform Preset when their PVs are not configured', async () => {
+    const ws = renderModbox()
+    await waitFor(() =>
+      expect(ws.subscriptions.get('SI_NL2_LOADED_WAVEFORM')?.size).toBe(1),
+    )
+
+    // Give the configured readouts real values: Modbox State shows a count,
+    // Waveform Latest a string — so the only remaining `<>` placeholders are
+    // the three unconfigured cells (MBC1, MBC2, Waveform Preset).
+    act(() => {
+      ws.push('BI_NL2_MODBOX_1', 1)
+      ws.push('BI_NL2_MODBOX_2', 1)
+      ws.push('BI_NL2_MODBOX_3', 1)
+      ws.push('SI_NL2_LOADED_WAVEFORM', 'std-100ps')
+    })
+
+    expect(screen.getAllByText('<>').length).toBe(3)
+  })
+
+  it('does not subscribe to MBC1/MBC2/Waveform Preset PVs when unconfigured', async () => {
+    const ws = renderModbox()
+    await waitFor(() =>
+      expect(ws.subscriptions.get('BI_NL2_MODBOX_1')?.size).toBe(1),
+    )
+    // Only the configured PVs (modbox + loaded waveform) get subscriptions;
+    // no undefined PV names leak into the subscription set.
+    expect([...ws.subscriptions.keys()]).toEqual(
+      expect.arrayContaining([...MODBOX_3, 'SI_NL2_LOADED_WAVEFORM']),
+    )
+    expect([...ws.subscriptions.keys()]).not.toContain(undefined)
   })
 
   it('exposes Modbox ON / Modbox OFF behind a cog toggle', async () => {

--- a/frontend/src/components/hmi/laser-panel/ModboxSection.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/ModboxSection.test.tsx
@@ -179,4 +179,41 @@ describe('ModboxSection', () => {
 
     expect(screen.getByRole('combobox')).toBeInTheDocument()
   })
+
+  it('counts only known-good numeric value===1 modboxes in the merged OK total', async () => {
+    const ws = renderModbox()
+    await waitFor(() =>
+      expect(ws.subscriptions.get('BI_NL2_MODBOX_1')?.size).toBe(1),
+    )
+    act(() => {
+      ws.push('BI_NL2_MODBOX_1', 1) // known-good → counts
+      ws.push('BI_NL2_MODBOX_2', { ok: false, value: 1 }) // !ok → excluded
+      ws.push('BI_NL2_MODBOX_3', { ok: true, value: null }) // null → excluded
+    })
+    // Only MODBOX_1 is known-good, so the merged count is 1 / 3 (not 2 / 3).
+    expect(screen.getByText('1 / 3')).toBeInTheDocument()
+  })
+
+  it('renders Modbox detail rows as unknown (N/A), not NO, for !ok or null values', async () => {
+    const ws = renderModbox()
+    await waitFor(() =>
+      expect(ws.subscriptions.get('BI_NL2_MODBOX_1')?.size).toBe(1),
+    )
+    act(() => {
+      ws.push('BI_NL2_MODBOX_1', 1)
+      ws.push('BI_NL2_MODBOX_2', { ok: false, value: 1 })
+      ws.push('BI_NL2_MODBOX_3', { ok: true, value: null })
+    })
+
+    const user = userEvent.setup()
+    await user.click(
+      screen.getByRole('button', { name: 'Toggle Modbox state detail' }),
+    )
+
+    expect(screen.getByText('Modbox 1')).toBeInTheDocument()
+    // MODBOX_1 = 1 → YES; the !ok and null rows are unknown (N/A), never NO.
+    expect(screen.getByText('YES')).toBeInTheDocument()
+    expect(screen.getAllByText('N/A')).toHaveLength(2)
+    expect(screen.queryByText('NO')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/hmi/laser-panel/ModboxSection.tsx
+++ b/frontend/src/components/hmi/laser-panel/ModboxSection.tsx
@@ -67,7 +67,7 @@ export const ModboxSection: FC<ModboxSectionProps> = ({
   // typed as `unknown` and narrow at the use site.
   const { state } = useWebSocketData<unknown>({ pvs: allPvs, raw: true })
   const okCount = modbox.filter(
-    (name) => state[name]?.value === 1,
+    (name) => state[name]?.ok && state[name]?.value === 1,
   ).length
   const total = modbox.length
   const tone =
@@ -81,11 +81,11 @@ export const ModboxSection: FC<ModboxSectionProps> = ({
 
   const items: DetailListItem[] = modbox.map((name, i) => {
     const msg = state[name]
-    const v = msg?.value
+    const known = msg && msg.ok && typeof msg.value === 'number'
     return {
       label: `Modbox ${i + 1}`,
-      state: !msg ? 'unknown' : v === 1 ? 'ok' : 'err',
-      trailing: !msg ? undefined : v === 1 ? 'YES' : 'NO',
+      state: !known ? 'unknown' : msg.value === 1 ? 'ok' : 'err',
+      trailing: !known ? undefined : msg.value === 1 ? 'YES' : 'NO',
     }
   })
 

--- a/frontend/src/components/hmi/laser-panel/ModboxSection.tsx
+++ b/frontend/src/components/hmi/laser-panel/ModboxSection.tsx
@@ -9,7 +9,7 @@ import {
   DetailList,
   DetailListItem,
 } from '@/components/hmi/controls/DetailList'
-import { StringValue } from '@/components/hmi/controls/Values'
+import { FloatValue, StringValue } from '@/components/hmi/controls/Values'
 import type { Message } from '@/app/providers/types'
 import { ChevronIcon } from '@/components/ui/icons'
 import { useWebSocketData } from '@/lib/websocket/use-websocket-data'
@@ -21,10 +21,16 @@ import styles from './sections.module.css'
 interface ModboxSectionProps {
   /** Laser id — used only to build command PVs. */
   laser: string
-  /** Modbox state PVs (1 = OK). */
+  /** Modbox state PVs (1 = OK) — merged into the BOOL count. */
   modbox: readonly string[]
-  /** Currently-loaded-waveform PV. */
+  /** Currently-loaded (latest) waveform PV. */
   loadedWaveformPv: string
+  /** Modbox State MBC1 float readout. Optional — absent → unknown (<>). */
+  mbc1Pv?: string
+  /** Modbox State MBC2 float readout. Optional — absent → unknown (<>). */
+  mbc2Pv?: string
+  /** Preset (next-launch) waveform PV. Optional — absent → unknown (<>). */
+  waveformPresetPv?: string
   /** Commands this laser exposes. Buttons for commands not listed are hidden. */
   commands: readonly LaserCommand[]
 }
@@ -37,6 +43,9 @@ export const ModboxSection: FC<ModboxSectionProps> = ({
   laser,
   modbox,
   loadedWaveformPv,
+  mbc1Pv,
+  mbc2Pv,
+  waveformPresetPv,
   commands,
 }) => {
   const [expanded, setExpanded] = useState(false)
@@ -44,8 +53,15 @@ export const ModboxSection: FC<ModboxSectionProps> = ({
   const hasModboxActions = can('MODBOX_ON') || can('MODBOX_OFF')
 
   const allPvs = useMemo(
-    () => [...modbox, loadedWaveformPv],
-    [modbox, loadedWaveformPv],
+    () =>
+      [
+        ...modbox,
+        loadedWaveformPv,
+        mbc1Pv,
+        mbc2Pv,
+        waveformPresetPv,
+      ].filter((p): p is string => Boolean(p)),
+    [modbox, loadedWaveformPv, mbc1Pv, mbc2Pv, waveformPresetPv],
   )
   // Mixed value types (number for state, string for waveform). Keep the hook
   // typed as `unknown` and narrow at the use site.
@@ -69,15 +85,23 @@ export const ModboxSection: FC<ModboxSectionProps> = ({
     return {
       label: `Modbox ${i + 1}`,
       state: !msg ? 'unknown' : v === 1 ? 'ok' : 'err',
+      trailing: !msg ? undefined : v === 1 ? 'YES' : 'NO',
     }
   })
 
   return (
     <SectionCard>
-      <DataRow
-        label="Modbox State"
-        valueVariant="bare"
-        value={
+      {/* BOOL (merged, expandable) + MBC1 / MBC2 float readouts, laid out as
+          columns to match the wireframe. MBC1/MBC2 fall back to the unknown
+          placeholder (<>) until their PVs are configured. */}
+      <div className={styles.modboxGrid}>
+        <span />
+        <span className={styles.colHeader}>BOOL</span>
+        <span className={styles.colHeader}>MBC1</span>
+        <span className={styles.colHeader}>MBC2</span>
+
+        <div className={styles.contents}>
+          <span className={styles.rowLabel}>Modbox State</span>
           <button
             type="button"
             className={styles.modboxStateButton}
@@ -94,30 +118,43 @@ export const ModboxSection: FC<ModboxSectionProps> = ({
               </span>
             </span>
           </button>
-        }
-        action={
-          hasModboxActions ? (
-            <CogToggle ariaLabel="Modbox actions">
-              {can('MODBOX_ON') && (
-                <ActionButton
-                  label="Set Modbox ON"
-                  pvName={pv.cmd(laser, 'MODBOX_ON')}
-                />
-              )}
-              {can('MODBOX_OFF') && (
-                <ActionButton
-                  label="Set Modbox OFF"
-                  pvName={pv.cmd(laser, 'MODBOX_OFF')}
-                  variant="secondary"
-                />
-              )}
-            </CogToggle>
-          ) : undefined
-        }
-      />
+          <span className={styles.numCell}>
+            <FloatValue
+              data={
+                mbc1Pv
+                  ? (state[mbc1Pv] as Message<number | null> | undefined)
+                  : undefined
+              }
+              precision={3}
+            />
+          </span>
+          <span className={styles.numCell}>
+            <FloatValue
+              data={
+                mbc2Pv
+                  ? (state[mbc2Pv] as Message<number | null> | undefined)
+                  : undefined
+              }
+              precision={3}
+            />
+          </span>
+        </div>
+      </div>
       {expanded && <DetailList items={items} />}
       <DataRow
-        label="Loaded Waveform"
+        label="Waveform Preset"
+        value={
+          <StringValue
+            data={
+              waveformPresetPv
+                ? (state[waveformPresetPv] as Message<string | null> | undefined)
+                : undefined
+            }
+          />
+        }
+      />
+      <DataRow
+        label="Waveform Latest"
         value={
           <StringValue
             data={state[loadedWaveformPv] as Message<string | null> | undefined}
@@ -131,6 +168,26 @@ export const ModboxSection: FC<ModboxSectionProps> = ({
           ) : undefined
         }
       />
+
+      {hasModboxActions && (
+        <div className={styles.actionRow}>
+          <CogToggle ariaLabel="Modbox actions" inlineLabel="Modbox Actions">
+            {can('MODBOX_ON') && (
+              <ActionButton
+                label="Set Modbox ON"
+                pvName={pv.cmd(laser, 'MODBOX_ON')}
+              />
+            )}
+            {can('MODBOX_OFF') && (
+              <ActionButton
+                label="Set Modbox OFF"
+                pvName={pv.cmd(laser, 'MODBOX_OFF')}
+                variant="secondary"
+              />
+            )}
+          </CogToggle>
+        </div>
+      )}
     </SectionCard>
   )
 }

--- a/frontend/src/components/hmi/laser-panel/OverviewBar.module.css
+++ b/frontend/src/components/hmi/laser-panel/OverviewBar.module.css
@@ -7,7 +7,9 @@
 
 .row {
   display: grid;
-  grid-template-columns: minmax(0, 4.5rem) minmax(0, 1fr);
+  /* First column matches DataRow's label column (7rem) so the CONN/FULLP/MSS/ERR
+     cluster lines up with the value cells in the rows below (Shutter, PHD…). */
+  grid-template-columns: minmax(0, 7rem) minmax(0, 1fr);
   gap: 0.375rem;
   align-items: center;
 }
@@ -65,6 +67,7 @@
 }
 
 .pill {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -83,6 +86,19 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Corner triangle marking an expandable pill (MSS, ERR — both wrapped in
+   .pillButton). Non-expandable pills (CONN, FULLP) get no triangle. */
+.pillButton .pill::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  border-style: solid;
+  border-width: 0 0 6px 6px;
+  border-color: transparent transparent var(--color-text) transparent;
+  opacity: 0.5;
 }
 
 .pillCount {

--- a/frontend/src/components/hmi/laser-panel/OverviewBar.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/OverviewBar.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { OverviewBar } from './OverviewBar'
+import {
+  makeFakeWebSocketContext,
+  TestWebSocketProvider,
+} from '@/test/ws-test-provider'
+
+function renderOverview() {
+  const ws = makeFakeWebSocketContext()
+  render(
+    <TestWebSocketProvider value={ws.context}>
+      <OverviewBar
+        connectionPv="CONN"
+        fullPowerPv="FULLP"
+        mssPvs={['MSS_1', 'MSS_2']}
+        moduleErrors={[{ label: 'Err A', pv: 'ERR_A' }]}
+      />
+    </TestWebSocketProvider>,
+  )
+  return ws
+}
+
+describe('OverviewBar', () => {
+  it('renders the CONN, FULLP, MSS and ERR overview cells', () => {
+    renderOverview()
+    expect(screen.getByText('CONN')).toBeInTheDocument()
+    expect(screen.getByText('FULLP')).toBeInTheDocument()
+    expect(screen.getByText('MSS')).toBeInTheDocument()
+    expect(screen.getByText('ERR')).toBeInTheDocument()
+  })
+
+  it('renders an MSS detail row as unknown (N/A), not NO, when ok but value is null', async () => {
+    const ws = renderOverview()
+    await waitFor(() => expect(ws.subscriptions.get('MSS_1')?.size).toBe(1))
+
+    act(() => {
+      // ok=true but value null — must read as unknown, not a "NO" indicator.
+      ws.push('MSS_1', { ok: true, value: null })
+      ws.push('MSS_2', 1)
+    })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Toggle MSS detail' }))
+
+    expect(screen.getByText('MSS 1')).toBeInTheDocument()
+    expect(screen.getByText('MSS 2')).toBeInTheDocument()
+    // MSS 1 (null) → unknown (N/A); MSS 2 (=1) → YES; nothing renders NO.
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+    expect(screen.getByText('YES')).toBeInTheDocument()
+    expect(screen.queryByText('NO')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/hmi/laser-panel/OverviewBar.tsx
+++ b/frontend/src/components/hmi/laser-panel/OverviewBar.tsx
@@ -71,7 +71,7 @@ export const OverviewBar: FC<OverviewBarProps> = ({
 
   const mssItems: DetailListItem[] = mssPvs.map((name, i) => {
     const msg = state[name]
-    const known = msg && msg.ok
+    const known = msg && msg.ok && typeof msg.value === 'number'
     return {
       label: `MSS ${i + 1}`,
       state: !known ? 'unknown' : msg.value === 1 ? 'ok' : 'err',

--- a/frontend/src/components/hmi/laser-panel/OverviewBar.tsx
+++ b/frontend/src/components/hmi/laser-panel/OverviewBar.tsx
@@ -71,10 +71,11 @@ export const OverviewBar: FC<OverviewBarProps> = ({
 
   const mssItems: DetailListItem[] = mssPvs.map((name, i) => {
     const msg = state[name]
+    const known = msg && msg.ok
     return {
       label: `MSS ${i + 1}`,
-      state:
-        !msg || !msg.ok ? 'unknown' : msg.value === 1 ? 'ok' : 'err',
+      state: !known ? 'unknown' : msg.value === 1 ? 'ok' : 'err',
+      trailing: !known ? undefined : msg.value === 1 ? 'YES' : 'NO',
     }
   })
 
@@ -154,7 +155,12 @@ export const OverviewBar: FC<OverviewBarProps> = ({
           </Cell>
         </div>
       </div>
-      {expanded === 'mss' && <DetailList items={mssItems} />}
+      {expanded === 'mss' && (
+        <DetailList
+          items={mssItems}
+          note="Selected MSS conditions — not an exhaustive list of all conditions behind the merged MSS indicator."
+        />
+      )}
       {expanded === 'err' && <DetailList items={errItems} />}
     </div>
   )

--- a/frontend/src/components/hmi/laser-panel/RegenSection.tsx
+++ b/frontend/src/components/hmi/laser-panel/RegenSection.tsx
@@ -50,7 +50,7 @@ export const RegenSection: FC<RegenSectionProps> = ({
       />
       <DataRow
         label="Regen Temp TK6:44"
-        value={<FloatValue data={state[regenTempPv]} precision={3} />}
+        value={<FloatValue data={state[regenTempPv]} precision={3} hideUnits />}
       />
       <DataRow
         label="PHD1K000:48/Mean"

--- a/frontend/src/components/hmi/laser-panel/SequencerSection.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/SequencerSection.test.tsx
@@ -77,4 +77,33 @@ describe('SequencerSection', () => {
     expect(screen.getByText('START soft')).toBeInTheDocument()
     expect(screen.getByText('System OFF')).toBeInTheDocument()
   })
+
+  it('renders a sequence row as unknown (N/A), not IDLE, when ok but value is null', async () => {
+    const ws = renderSequencer({
+      sequencerPv: 'SEQ_NL2_STATE',
+      sequences: [
+        { label: 'START soft', pv: 'SEQ_NL2_START_SOFT' },
+        { label: 'System OFF', pv: 'SEQ_NL2_SYSTEM_OFF' },
+      ],
+    })
+    await waitFor(() =>
+      expect(ws.subscriptions.get('SEQ_NL2_START_SOFT')?.size).toBe(1),
+    )
+    act(() => {
+      // ok=true but no numeric value yet — must stay unknown, not fall to IDLE.
+      ws.push('SEQ_NL2_START_SOFT', { ok: true, value: null })
+      ws.push('SEQ_NL2_SYSTEM_OFF', 1)
+    })
+
+    const user = userEvent.setup()
+    await user.click(
+      screen.getByRole('button', { name: 'Toggle sequencer detail' }),
+    )
+
+    expect(screen.getByText('START soft')).toBeInTheDocument()
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+    // A valid numeric sequence still resolves to RUNNING.
+    expect(screen.getByText('RUNNING')).toBeInTheDocument()
+    expect(screen.queryByText('IDLE')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/hmi/laser-panel/SequencerSection.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/SequencerSection.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SequencerSection } from './SequencerSection'
+import type { LabeledPv } from '@/app/(modules)/l4-opcpa/config/schema'
+import {
+  makeFakeWebSocketContext,
+  TestWebSocketProvider,
+} from '@/test/ws-test-provider'
+
+function renderSequencer(props: {
+  sequencerPv?: string
+  sequences?: readonly LabeledPv[]
+}) {
+  const ws = makeFakeWebSocketContext()
+  render(
+    <TestWebSocketProvider value={ws.context}>
+      <SequencerSection {...props} />
+    </TestWebSocketProvider>,
+  )
+  return ws
+}
+
+describe('SequencerSection', () => {
+  it('renders a compact Sequencer row showing the unknown placeholder when no PV is configured', () => {
+    renderSequencer({})
+    expect(screen.getByText('Sequencer')).toBeInTheDocument()
+    // No sequencer PV → unknown placeholder, not IDLE/RUNNING.
+    expect(screen.getByText('<>')).toBeInTheDocument()
+    expect(screen.queryByText('IDLE')).not.toBeInTheDocument()
+    expect(screen.queryByText('RUNNING')).not.toBeInTheDocument()
+  })
+
+  it('is not expandable when no per-sequence detail PVs are configured', () => {
+    renderSequencer({ sequencerPv: 'SEQ_NL2_STATE' })
+    expect(
+      screen.queryByRole('button', { name: 'Toggle sequencer detail' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows IDLE / RUNNING from the configured sequencer PV', async () => {
+    const ws = renderSequencer({ sequencerPv: 'SEQ_NL2_STATE' })
+    await waitFor(() =>
+      expect(ws.subscriptions.get('SEQ_NL2_STATE')?.size).toBe(1),
+    )
+
+    act(() => ws.push('SEQ_NL2_STATE', 0))
+    expect(screen.getByText('IDLE')).toBeInTheDocument()
+
+    act(() => ws.push('SEQ_NL2_STATE', 1))
+    expect(screen.getByText('RUNNING')).toBeInTheDocument()
+  })
+
+  it('expands into a per-sequence detail list when sequence PVs are configured', async () => {
+    const ws = renderSequencer({
+      sequencerPv: 'SEQ_NL2_STATE',
+      sequences: [
+        { label: 'START soft', pv: 'SEQ_NL2_START_SOFT' },
+        { label: 'System OFF', pv: 'SEQ_NL2_SYSTEM_OFF' },
+      ],
+    })
+    await waitFor(() =>
+      expect(ws.subscriptions.get('SEQ_NL2_START_SOFT')?.size).toBe(1),
+    )
+    act(() => {
+      ws.push('SEQ_NL2_START_SOFT', 1)
+      ws.push('SEQ_NL2_SYSTEM_OFF', 0)
+    })
+
+    const user = userEvent.setup()
+    expect(screen.queryByText('START soft')).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Toggle sequencer detail' }),
+    )
+
+    expect(screen.getByText('START soft')).toBeInTheDocument()
+    expect(screen.getByText('System OFF')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/hmi/laser-panel/SequencerSection.tsx
+++ b/frontend/src/components/hmi/laser-panel/SequencerSection.tsx
@@ -50,7 +50,7 @@ export const SequencerSection: FC<SequencerSectionProps> = ({
   const items: DetailListItem[] = (sequences ?? []).map(
     ({ label, pv: name }) => {
       const msg = state[name]
-      const known = msg && msg.ok
+      const known = msg && msg.ok && typeof msg.value === 'number'
       return {
         label,
         state: !known ? 'unknown' : msg.value === 1 ? 'run' : 'sb',

--- a/frontend/src/components/hmi/laser-panel/SequencerSection.tsx
+++ b/frontend/src/components/hmi/laser-panel/SequencerSection.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { FC, useMemo, useState } from 'react'
+import { SectionCard } from '@/components/hmi/controls/SectionCard'
+import { DataRow } from '@/components/hmi/controls/DataRow'
+import { BoolPill } from '@/components/hmi/controls/Values'
+import {
+  DetailList,
+  DetailListItem,
+} from '@/components/hmi/controls/DetailList'
+import { ChevronIcon } from '@/components/ui/icons'
+import { useWebSocketData } from '@/lib/websocket/use-websocket-data'
+import type { LabeledPv } from '@/app/(modules)/l4-opcpa/config/schema'
+import styles from './sections.module.css'
+
+interface SequencerSectionProps {
+  /** Sequencer state PV (1 = RUNNING, 0 = IDLE). Optional — when absent the
+   * row renders the unknown placeholder (<>). */
+  sequencerPv?: string
+  /** Per-sequence state indicators for the expanded list. Optional/empty →
+   * the row is NOT expandable (no configured sequence detail to show). */
+  sequences?: readonly LabeledPv[]
+}
+
+/**
+ * Sequencer status row at the top of the panel. Per the spec it shows whether
+ * the sequencer is IDLE or RUNNING, and (only when per-sequence detail PVs are
+ * configured) can be expanded into a list of all sequences with their current
+ * state. No sequencer PVs are invented here: absent config → unknown (<>),
+ * non-expandable.
+ */
+export const SequencerSection: FC<SequencerSectionProps> = ({
+  sequencerPv,
+  sequences,
+}) => {
+  const [expanded, setExpanded] = useState(false)
+  const expandable = (sequences?.length ?? 0) > 0
+
+  const allPvs = useMemo(
+    () =>
+      [sequencerPv, ...(sequences?.map((s) => s.pv) ?? [])].filter(
+        (p): p is string => Boolean(p),
+      ),
+    [sequencerPv, sequences],
+  )
+  const { state } = useWebSocketData<number | null>({ pvs: allPvs, raw: true })
+
+  const stateMsg = sequencerPv ? state[sequencerPv] : undefined
+
+  const items: DetailListItem[] = (sequences ?? []).map(
+    ({ label, pv: name }) => {
+      const msg = state[name]
+      const known = msg && msg.ok
+      return {
+        label,
+        state: !known ? 'unknown' : msg.value === 1 ? 'run' : 'sb',
+        trailing: !known ? undefined : msg.value === 1 ? 'RUNNING' : 'IDLE',
+      }
+    },
+  )
+
+  const pill = (
+    <BoolPill
+      data={stateMsg}
+      onLabel="RUNNING"
+      offLabel="IDLE"
+      onTone="positive-important"
+      offTone="positive-neutral"
+    />
+  )
+
+  return (
+    <SectionCard>
+      <DataRow
+        label="Sequencer"
+        valueVariant="bare"
+        value={
+          expandable ? (
+            <button
+              type="button"
+              className={styles.flashlampStateButton}
+              aria-expanded={expanded}
+              aria-label="Toggle sequencer detail"
+              onClick={() => setExpanded((v) => !v)}
+            >
+              <span>{pill}</span>
+              <span className={styles.flashlampStateChevron}>
+                <ChevronIcon expanded={expanded} />
+              </span>
+            </button>
+          ) : (
+            pill
+          )
+        }
+      />
+      {expandable && expanded && <DetailList items={items} />}
+    </SectionCard>
+  )
+}

--- a/frontend/src/components/hmi/laser-panel/sections.module.css
+++ b/frontend/src/components/hmi/laser-panel/sections.module.css
@@ -1,10 +1,20 @@
 .actionRow {
-  display: flex;
-  justify-content: flex-end;
+  display: grid;
+  /* Same columns as DataRow so the actions cog starts at the value column —
+     i.e. lines up with the value cells in the rows above it. */
+  grid-template-columns: minmax(0, 7rem) minmax(0, 1fr) auto;
+  gap: 0.375rem;
+  align-items: center;
   padding-top: 0.25rem;
 }
 
-.chillerGrid {
+.actionRow > * {
+  grid-column: 2 / -1;
+  justify-self: start;
+}
+
+.chillerGrid,
+.modboxGrid {
   display: grid;
   grid-template-columns: minmax(0, 7rem) repeat(3, minmax(0, 1fr));
   gap: 0.25rem 0.375rem;
@@ -49,12 +59,13 @@
 }
 
 .flashlampStateButton {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
   background: transparent;
   border: none;
-  padding: 0;
+  padding: 0 0.5rem 0 0;
   margin: 0;
   cursor: pointer;
   font: inherit;
@@ -62,6 +73,18 @@
   color: var(--color-text);
   text-align: left;
   min-width: 0;
+}
+
+/* Corner triangle marking the row as expandable. */
+.flashlampStateButton::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  border-style: solid;
+  border-width: 0 0 6px 6px;
+  border-color: transparent transparent var(--color-text) transparent;
+  opacity: 0.5;
 }
 
 .flashlampStateButton > span:first-child {
@@ -175,6 +198,7 @@
 }
 
 .modboxStatePill {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -187,6 +211,18 @@
   background: var(--color-surface-lighter);
   border: 1px solid var(--color-text);
   color: var(--color-text);
+}
+
+/* Corner triangle marking the Modbox state pill as expandable. */
+.modboxStatePill::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  border-style: solid;
+  border-width: 0 0 6px 6px;
+  border-color: transparent transparent var(--color-text) transparent;
+  opacity: 0.5;
 }
 
 .modboxStatePill[data-tone='positive-important'] {


### PR DESCRIPTION
## Summary

Aligns the L4 OPCPA NL2 panel with the current requirements/wireframe.

Changes include:
- Limits the L4 OPCPA page to the current NL2 rollout target.
- Adds the Sequencer row with placeholder behavior until real sequencer PVs are configured.
- Completes the Modbox structure with BOOL, MBC1, MBC2, Waveform Preset, Waveform Latest, and Modbox Actions.
- Fixes visual alignment for overview/action rows.
- Removes duplicate expanded-list indicators and uses readable text status labels.
- Adds corner markers for expandable controls.
- Removes the `°C` unit from `Regen Temp TK6:44`.
- Removes `CANCEL` from Attenuator and Trigger Delay custom controls.
- Makes Trigger Delay presets `50`, `500`, `700`, and `790` apply immediately.
- Adjusts shared cog popover positioning so action panels do not clip under the sidebar.

## Validation

- [x] `npm run lint`
- [x] Targeted tests: `npx vitest --run src/components/hmi/laser-panel src/components/hmi/controls 'src/app/(modules)/l4-opcpa'`
  - 16 files passed
  - 67 tests passed
- [x] `npm run build`
- [x] Manual browser check completed for CSI-755 through CSI-761

## Notes

Full `npm run test:run` still has 6 existing failures in `zone-service.test.ts` / `middleware.test.ts` route expectations (`/p3-controls` vs `/l4-opcpa`). These reproduce outside this UI diff and are unrelated to the NL2 panel changes.

`lasers.yaml` does not currently provide Sequencer, per-sequence, MBC1, MBC2, or Waveform Preset PVs for NL2. The UI renders placeholders for those fields and will subscribe to them once real PV names are configured.