### PR TITLE
fix(hmi): portal cog dropdowns + adaptive multi-device laser grid

### DIFF
--- a/frontend/src/app/(modules)/l4-opcpa/components/laser-grid.module.css
+++ b/frontend/src/app/(modules)/l4-opcpa/components/laser-grid.module.css
@@ -1,13 +1,16 @@
 .grid {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap; /* panels wrap to fit any width: 1/row on phones, 5+/row on wide monitors */
   gap: 0.75rem;
   padding: 0.5rem 0;
   align-items: start;
+  align-content: flex-start;
   color: var(--color-text);
 }
 
 .grid > * {
-  width: 280px;
-  flex-shrink: 0;
+  width: 20rem; /* = 280px at the 14px base; rem so panels scale with the fluid root font-size */
+  max-width: 100%; /* never overflow a viewport narrower than a single panel */
+  flex: 0 0 auto;
 }

--- a/frontend/src/app/(modules)/l4-opcpa/components/laser-grid.tsx
+++ b/frontend/src/app/(modules)/l4-opcpa/components/laser-grid.tsx
@@ -2,8 +2,9 @@ import { FC, PropsWithChildren } from 'react'
 import styles from './laser-grid.module.css'
 
 /**
- * Flex row of fixed-width (280px) laser panels.
- * Horizontal overflow is caught by the global .page-container scroll container.
+ * Responsive grid of laser panels. Each panel is a fixed rem width; the grid
+ * wraps, so the number of panels per row adapts to the viewport — one per
+ * row on a phone, the full set on a wide control-room display.
  */
 export const LaserGrid: FC<PropsWithChildren> = ({ children }) => {
   return <div className={styles.grid}>{children}</div>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -105,7 +105,7 @@ a {
 
 html {
   font-size: 14px;
-  font-family: 'Roboto Condensed', sans-serif;
+  font-family: 'Roboto Condensed', 'Arial Narrow', 'Roboto', system-ui, sans-serif; /* condensed fallbacks: if Roboto Condensed fails to load, degrade to a narrow face instead of a wide sans-serif that overflows fixed-width labels */
   background: var(--color-background);
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -99,12 +99,21 @@ body {
   align-self: stretch;
 }
 
+/* Narrow screens (portrait phones / small tablets): stack the status sidebar
+   above the content so a panel gets the full viewport width instead of being
+   crushed beside the sidebar. */
+@media (max-width: 640px) {
+  .layout-container {
+    flex-direction: column;
+  }
+}
+
 a {
   text-decoration: none;
 }
 
 html {
-  font-size: 14px;
+  font-size: clamp(12.5px, 0.5vw + 4.5px, 18px); /* fluid base unit so the rem-based UI adapts from phones to large control-room displays: 12.5px floor keeps five panels in one row at ~1600px, scaling to 18px on 4K for across-room readability. Panels, gaps and text scale together, so nothing truncates; browser zoom still layers on top. */
   font-family: 'Roboto Condensed', 'Arial Narrow', 'Roboto', system-ui, sans-serif; /* condensed fallbacks: if Roboto Condensed fails to load, degrade to a narrow face instead of a wide sans-serif that overflows fixed-width labels */
   background: var(--color-background);
 }

--- a/frontend/src/components/hmi/controls/CogToggle.tsx
+++ b/frontend/src/components/hmi/controls/CogToggle.tsx
@@ -8,9 +8,11 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react'
+import { createPortal } from 'react-dom'
 import { SettingsIcon } from '@/components/ui/icons'
 import styles from './CogToggle.module.css'
 
@@ -34,9 +36,15 @@ export const useCogToggleClose = (): (() => void) =>
   useContext(CogToggleContext)
 
 /**
- * Cog-icon button that toggles an inline panel of write actions. The panel
+ * Cog-icon button that toggles a panel of write actions. The panel
  * closes on Escape, on outside-click, and when a descendant write control
  * reports success via useCogToggleClose.
+ *
+ * The panel is portaled to <body> and fixed-positioned under the button.
+ * Rendering it in place (position: absolute) let the scrollable page
+ * container (`.page-container { overflow: auto }`) clip it at the viewport
+ * edges — dropdowns opened near the status bar or below the fold were cut
+ * off. Portaling is the same mechanism the tooltip uses to stay visible.
  */
 export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
   ariaLabel,
@@ -44,7 +52,10 @@ export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
   children,
 }) => {
   const [open, setOpen] = useState(false)
+  const [pos, setPos] = useState<{ top: number; right: number } | null>(null)
   const wrapperRef = useRef<HTMLSpanElement | null>(null)
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const panelRef = useRef<HTMLDivElement | null>(null)
 
   const close = useCallback(() => setOpen(false), [])
 
@@ -57,23 +68,51 @@ export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
     return () => window.removeEventListener('keydown', onKey)
   }, [open, close])
 
+  // The panel is portaled outside the wrapper, so clicks inside it must not
+  // count as "outside" — check both refs.
   useEffect(() => {
     if (!open) return
     const onDown = (e: MouseEvent) => {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(e.target as Node)
-      ) {
-        close()
-      }
+      const target = e.target as Node
+      if (wrapperRef.current?.contains(target)) return
+      if (panelRef.current?.contains(target)) return
+      close()
     }
     window.addEventListener('mousedown', onDown)
     return () => window.removeEventListener('mousedown', onDown)
   }, [open, close])
 
+  // Fixed-position the panel below the button, right-aligned to it. Flip it
+  // above the button when there is not enough room below, and follow the
+  // button on scroll (capture phase catches scrolling ancestors) and resize.
+  useLayoutEffect(() => {
+    if (!open) return
+    const place = () => {
+      const button = buttonRef.current
+      if (!button) return
+      const rect = button.getBoundingClientRect()
+      const gap = 4
+      const panelHeight = panelRef.current?.offsetHeight ?? 0
+      let top = rect.bottom + gap
+      if (panelHeight && top + panelHeight > window.innerHeight - 8) {
+        top = Math.max(8, rect.top - panelHeight - gap)
+      }
+      const right = Math.max(8, window.innerWidth - rect.right)
+      setPos({ top, right })
+    }
+    place()
+    window.addEventListener('scroll', place, true)
+    window.addEventListener('resize', place)
+    return () => {
+      window.removeEventListener('scroll', place, true)
+      window.removeEventListener('resize', place)
+    }
+  }, [open])
+
   return (
     <span className={styles.wrapper} ref={wrapperRef}>
       <button
+        ref={buttonRef}
         type="button"
         className={styles.button}
         aria-label={ariaLabel}
@@ -85,11 +124,26 @@ export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
           <span className={styles.inlineLabel}>{inlineLabel}</span>
         ) : null}
       </button>
-      {open ? (
-        <CogToggleContext.Provider value={close}>
-          <div className={styles.panel}>{children}</div>
-        </CogToggleContext.Provider>
-      ) : null}
+      {open && typeof document !== 'undefined'
+        ? createPortal(
+            <CogToggleContext.Provider value={close}>
+              <div
+                ref={panelRef}
+                className={styles.panel}
+                style={{
+                  position: 'fixed',
+                  top: pos?.top ?? 0,
+                  right: pos?.right ?? 0,
+                  zIndex: 1000,
+                  visibility: pos ? 'visible' : 'hidden',
+                }}
+              >
+                {children}
+              </div>
+            </CogToggleContext.Provider>,
+            document.body,
+          )
+        : null}
     </span>
   )
 }

--- a/frontend/src/components/hmi/laser-panel/LaserPanel.module.css
+++ b/frontend/src/components/hmi/laser-panel/LaserPanel.module.css
@@ -5,7 +5,7 @@
   background: var(--color-surface);
   border: 1px solid var(--color-text-secondary);
   padding: 0;
-  min-width: 280px;
+  min-width: 20rem; /* = 280px at the 14px base; rem so the panel scales with the fluid root font-size */
   color: var(--color-text);
 }
 


### PR DESCRIPTION
## Summary

Three small, independent changes to the L4 OPCPA HMI (5 files, +86/−19):

1. **`fix(hmi)`: portal the floating CogToggle dropdown to `<body>`** — cog action panels were clipped by the scrollable page container.
2. **`fix(hmi)`: condensed font fallbacks** — a failed Roboto Condensed load no longer falls back to a wide sans-serif that truncates fixed-width labels.
3. **`feat(hmi)`: adaptive multi-device layout** — the laser grid wraps and the rem-based UI scales fluidly, so the same page works from a phone to a 4K control-room display, with all five panels in one row from ~1600 px up.

## Problems and root causes

**Dropdown clipping.** `CogToggle`'s panel was `position: absolute; z-index: 5`, rendered inside `.page-container { overflow: auto }`. Any panel opened near the container edge or below the fold was cut off at the scroll boundary (visually it looks like the status bar / viewport "hides the pop-up"). The tooltip never had this problem because it portals to `<body>`; the dropdown now uses the same mechanism: portaled, `position: fixed`, `z-index: 1000`, right-aligned under its button, flipping above the button when there is no room below, repositioning on scroll/resize. Escape, outside-click and `useCogToggleClose` behave exactly as before (outside-click also checks the portaled panel). No call-site changes; component API unchanged.

**Rigid layout.** The grid was a non-wrapping row of hardcoded `280px` panels: with five lasers it overflows horizontally below ~1650 px and cannot adapt to tablets, phones, or large displays. Changes: the grid wraps; panel width/min-width become `20rem` (pixel-identical to `280px` at the current `14px` base); the root font-size becomes `clamp(12.5px, 0.5vw + 4.5px, 18px)` so panels, gaps and text scale together (nothing can truncate, because everything scales in lockstep); the status sidebar stacks above the content at ≤640 px.

## Verification (all on this branch)

Toolchain gates: `tsc` clean, `eslint` clean, **vitest 131/131 (25 files)**, `next build` clean. No existing test needed modification — the portal renders into `document.body`, which testing-library queries cover.

Browser measurements on the real five-panel `/l4-opcpa` page (Chromium, mock backend):

| viewport | root font | panel | panels/row | truncated labels | h-overflow | sidebar |
|---|---|---|---|---|---|---|
| 360 / 390 px | 12.5 px | 250 px | 1 | 0 / 51 | none | stacked on top |
| 768 px | 12.5 px | 250 px | 2 | 0 / 51 | none | side-by-side |
| 1024 px | 12.5 px | 250 px | 3 | 0 / 51 | none | side-by-side |
| 1366 px | 12.5 px | 250 px | 4 | 0 / 51 | none | side-by-side |
| **1600 px** | 12.5 px | 250 px | **5** | 0 / 51 | none | side-by-side |
| 1920 px | 14.1 px | 282 px | 5 | 0 / 51 | none | side-by-side |
| 2560 px | 17.3 px | 346 px | 5 | 0 / 51 | none | side-by-side |
| 3840 px | 18 px | 360 px | 5 | 0 / 51 | none | side-by-side |

Dropdown: with a 470 px-tall viewport, a low cog ("Set waveform") opens **fully on-screen, flipped above the button**, and the panel reports `parent=BODY, position=fixed, z-index=1000`.

One environment note: this branch was verified outside the ELI network, so `npm ci` used the public registry via a local `npm_config_registry` override — `package-lock.json` and `.npmrc` are untouched, and lockfile integrity hashes verified the identical package contents.

## Risk & rollback

- The fluid root font-size is **global**: every rem-based route scales with the viewport (13→18 px instead of fixed 14 px). At 1920 px the UI renders ~0.7 % larger than today (14.1 px root); on smaller laptops slightly smaller, on 4K larger by design. If that is unwanted, reverting the single `feat(hmi)` commit restores the previous fixed layout while keeping both fixes.
- `280px → 20rem` is pixel-identical at the default base; it only matters once the root scales.
- The portal changes stacking, not behavior: the panel now reliably renders above sticky headers (which sit at z-index ≤ 10).

## Out of scope (deliberately)

A separate density/token-based restyling of the panel internals (from a downstream snapshot of this repo) was **not** ported: it presupposes a CSS-token structure this branch does not have, and porting it would have meant restyling unrelated upstream work. Available as a follow-up if wanted.
