### PR TITLE
Replace L4 OPCPA UI with the validated NL2 snapshot (frontend + mock)

### DIFF
--- a/backend/mockup-websocket-server/l4_opcpa.go
+++ b/backend/mockup-websocket-server/l4_opcpa.go
@@ -3,7 +3,9 @@
 // `${L}` as a placeholder for the laser id; substituteLaser swaps it in.
 //
 // PV names mirror the canonical frontend registry at:
-//   frontend/src/app/(modules)/l4-opcpa/lib/pv-names.ts
+//
+//	frontend/src/app/(modules)/l4-opcpa/lib/pv-names.ts
+//
 // Keep these two files in sync — drift = the mock seeds PVs the frontend
 // doesn't subscribe to, or vice versa.
 //
@@ -11,7 +13,8 @@
 // mirror frontend/src/app/(modules)/l4-opcpa/components/laser-specs.ts.
 //
 // Source spec:
-//   https://eli-eric.atlassian.net/wiki/spaces/CS/pages/2333902150
+//
+//	https://eli-eric.atlassian.net/wiki/spaces/CS/pages/2333902150
 package main
 
 import (
@@ -39,7 +42,8 @@ const (
 // sequenceFailRate is 1/N: write fails with probability 1/N. Controlled at
 // runtime via `GET /mode/fail-rate/<n>` (0 disables, default 0 = off).
 // Demos that want to exercise the error UX should opt in:
-//   curl http://localhost:8080/mode/fail-rate/10   # 10% failures
+//
+//	curl http://localhost:8080/mode/fail-rate/10   # 10% failures
 var sequenceFailRate int32 = 0
 
 var (
@@ -207,10 +211,20 @@ var sequences = map[string]sequenceFunc{
 	// Attenuator + Shutter are direct PV writes (`AI_<L>_ATT`, `BI_<L>_SHUTTER`)
 	// — no sequence needed, the operator just writes the value/state.
 	"load_waveform": func(laser string, value interface{}) ([]pvEffect, error) {
-		if value == nil {
+		waveform, ok := value.(string)
+		if !ok || strings.TrimSpace(waveform) == "" {
 			return nil, fmt.Errorf("load_waveform requires a waveform name")
 		}
-		return tpls(laser, pvEffect{"SI_${L}_LOADED_WAVEFORM", value}), nil
+
+		// Waveform Preset is the newly selected waveform. Waveform Latest is
+		// the preset that was active immediately before this command. This
+		// mirrors the UI requirement: changing the waveform pushes the previous
+		// preset into the Latest row instead of echoing the new preset there.
+		previousPreset := currentPVValue(fmt.Sprintf("SI_%s_LOADED_WAVEFORM", laser))
+		return tpls(laser,
+			pvEffect{"SI_${L}_LATEST_WAVEFORM", previousPreset},
+			pvEffect{"SI_${L}_LOADED_WAVEFORM", strings.TrimSpace(waveform)},
+		), nil
 	},
 }
 
@@ -223,10 +237,10 @@ type writePvRequest struct {
 // writePvHandler is the single write endpoint. Every action in the UI is a
 // `POST /pv/<NAME>` with body `{value: ...}`. Two flavours:
 //
-//   * Command PVs (prefix `CMD_<LASER>_<NAME>`): the value is the trigger; the
+//   - Command PVs (prefix `CMD_<LASER>_<NAME>`): the value is the trigger; the
 //     dispatcher looks up the named effect chain in `sequences` and applies it
 //     to all affected PVs in addition to setting the command PV itself.
-//   * Plain PVs (everything else): a direct manual write, broadcast to
+//   - Plain PVs (everything else): a direct manual write, broadcast to
 //     subscribed clients over WS.
 func writePvHandler(c echo.Context) error {
 	name := strings.TrimSpace(c.Param("name"))
@@ -293,6 +307,25 @@ func writePvHandler(c echo.Context) error {
 		// Reflect the command PV itself so subscribers can see it was fired.
 		ps := getOrCreateSim(name)
 		ps.setManualValueHeld(body.Value, "", sequenceHold)
+
+		// PROOF-OF-CONCEPT: drive the per-sequence + overall Sequencer state.
+		// Firing CMD_<laser>_<ID> shows that sequence (and the Sequencer) as
+		// RUNNING for the hold window, then returns to IDLE. Real control system
+		// has no per-sequence state PV yet — this mocks it for the expanded
+		// Sequencer view.
+		if rest := strings.TrimPrefix(name, "CMD_"); rest != name {
+			if parts := strings.SplitN(rest, "_", 2); len(parts) == 2 && parts[0] != "" {
+				seqPv := fmt.Sprintf("BI_%s_SEQ_%s", parts[0], strings.ToUpper(parts[1]))
+				runPv := fmt.Sprintf("BI_%s_SEQUENCER_RUNNING", parts[0])
+				getOrCreateSim(seqPv).setManualValue(1, "")
+				getOrCreateSim(runPv).setManualValue(1, "")
+				time.AfterFunc(sequenceHold, func() {
+					getOrCreateSim(seqPv).setManualValue(0, "")
+					getOrCreateSim(runPv).setManualValue(0, "")
+				})
+			}
+		}
+
 		log.Printf("pv write %s = %v → %d effects", name, body.Value, len(effects))
 		return c.JSON(http.StatusOK, map[string]interface{}{
 			"ok":      true,
@@ -344,6 +377,13 @@ func commandPVEffects(name string, value interface{}) ([]pvEffect, error) {
 	return seq(laser, value)
 }
 
+func currentPVValue(name string) interface{} {
+	ps := getOrCreateSim(name)
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	return ps.value
+}
+
 func isKnownLaser(id string) bool {
 	for _, l := range allLasers {
 		if l == id {
@@ -378,6 +418,18 @@ func setFailRateHandler(c echo.Context) error {
 
 // seedLaserPVs primes the per-laser PV registry with at-rest defaults so the
 // frontend has a stable picture immediately after boot.
+// sequencerSeqIDs are the command ids surfaced as individual sequences in the
+// expanded Sequencer (PROOF-OF-CONCEPT). They mirror the frontend
+// L4_OPCPA_SEQUENCES ids; the per-sequence state PV is BI_<laser>_SEQ_<id>.
+var sequencerSeqIDs = []string{
+	"START_LASER",
+	"STOP_LASER",
+	"ALIGNMENT_MODE",
+	"SYSTEM_STANDBY",
+	"FLASHLAMPS_RUN",
+	"FLASHLAMPS_STANDBY",
+}
+
 func seedLaserPVs() {
 	for _, laser := range allLasers {
 		// general
@@ -415,6 +467,14 @@ func seedLaserPVs() {
 			setSeed(fmt.Sprintf("BI_%s_MODBOX_%d", laser, i), 1)
 		}
 		setSeed(fmt.Sprintf("SI_%s_LOADED_WAVEFORM", laser), "(none)")
+		setSeed(fmt.Sprintf("SI_%s_LATEST_WAVEFORM", laser), "(none)")
+		// Sequencer (PROOF-OF-CONCEPT): overall + per-sequence state, all IDLE
+		// at start. No real per-sequence PV exists yet; these are mocked so the
+		// expanded Sequencer can show individual IDLE/RUNNING per the spec.
+		setSeed(fmt.Sprintf("BI_%s_SEQUENCER_RUNNING", laser), 0)
+		for _, id := range sequencerSeqIDs {
+			setSeed(fmt.Sprintf("BI_%s_SEQ_%s", laser, id), 0)
+		}
 	}
 }
 

--- a/backend/mockup-websocket-server/seq_poc_test.go
+++ b/backend/mockup-websocket-server/seq_poc_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// readPV returns the current simulated value of a PV (lock-safe).
+func readPV(name string) interface{} {
+	ps := getOrCreateSim(name)
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	return ps.value
+}
+
+func asInt(v interface{}) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}
+
+// TestSequencerPerSequenceStatePoC verifies the proof-of-concept: firing a
+// sequence command flips that sequence's state PV (and the overall Sequencer)
+// to RUNNING (1) for the hold window, then back to IDLE (0).
+func TestSequencerPerSequenceStatePoC(t *testing.T) {
+	e := newServer()
+	seedLaserPVs()
+
+	const seqPV = "BI_NL2_SEQ_START_LASER"
+	const runPV = "BI_NL2_SEQUENCER_RUNNING"
+
+	// Seeded IDLE.
+	if v, _ := asInt(readPV(seqPV)); v != 0 {
+		t.Fatalf("expected %s seeded IDLE(0), got %v", seqPV, readPV(seqPV))
+	}
+	if v, _ := asInt(readPV(runPV)); v != 0 {
+		t.Fatalf("expected %s seeded IDLE(0), got %v", runPV, readPV(runPV))
+	}
+
+	// Fire the command (POST /pv/CMD_NL2_START_LASER {"value":1}).
+	body := strings.NewReader(`{"value":1}`)
+	req := httptest.NewRequest(http.MethodPost, "/pv/CMD_NL2_START_LASER", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "test")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fire failed: status %d body %s", rec.Code, rec.Body.String())
+	}
+
+	// Immediately after the write the sequence + Sequencer read RUNNING(1).
+	if v, _ := asInt(readPV(seqPV)); v != 1 {
+		t.Fatalf("expected %s RUNNING(1) after fire, got %v", seqPV, readPV(seqPV))
+	}
+	if v, _ := asInt(readPV(runPV)); v != 1 {
+		t.Fatalf("expected %s RUNNING(1) after fire, got %v", runPV, readPV(runPV))
+	}
+	fmt.Printf("PoC after fire:  %s=1 (RUNNING)  %s=1 (RUNNING)\n", seqPV, runPV)
+
+	// After the hold window the timed reset returns both to IDLE(0).
+	time.Sleep(sequenceHold + 500*time.Millisecond)
+	if v, _ := asInt(readPV(seqPV)); v != 0 {
+		t.Fatalf("expected %s IDLE(0) after hold, got %v", seqPV, readPV(seqPV))
+	}
+	if v, _ := asInt(readPV(runPV)); v != 0 {
+		t.Fatalf("expected %s IDLE(0) after hold, got %v", runPV, readPV(runPV))
+	}
+	fmt.Printf("PoC after hold:  %s=0 (IDLE)     %s=0 (IDLE)\n", seqPV, runPV)
+}

--- a/backend/mockup-websocket-server/waveform_transition_test.go
+++ b/backend/mockup-websocket-server/waveform_transition_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func resetPVRegistryForTest() {
+	pvRegistryMu.Lock()
+	defer pvRegistryMu.Unlock()
+	for _, ps := range pvRegistry {
+		ps.cancel()
+	}
+	pvRegistry = make(map[string]*pvSim)
+}
+
+func postWaveformCommand(t *testing.T, e http.Handler, laser string, waveform string) {
+	t.Helper()
+	body := strings.NewReader(`{"value":"` + waveform + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/pv/CMD_"+laser+"_LOAD_WAVEFORM", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "test")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("waveform command failed: status %d body %s", rec.Code, rec.Body.String())
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if payload["ok"] != true {
+		t.Fatalf("expected ok response, got %s", rec.Body.String())
+	}
+}
+
+func TestLoadWaveformMovesPreviousPresetToLatest(t *testing.T) {
+	resetPVRegistryForTest()
+	atomic.StoreInt32(&sequenceFailRate, 0)
+
+	e := newServer()
+	seedLaserPVs()
+
+	const loadedPV = "SI_NL2_LOADED_WAVEFORM"
+	const latestPV = "SI_NL2_LATEST_WAVEFORM"
+	setSeed(loadedPV, "std-100ps")
+	setSeed(latestPV, "older-setup")
+
+	postWaveformCommand(t, e, "NL2", "narrow-50ps")
+
+	if got := readPV(loadedPV); got != "narrow-50ps" {
+		t.Fatalf("expected Waveform Preset %s to become %q, got %v", loadedPV, "narrow-50ps", got)
+	}
+	if got := readPV(latestPV); got != "std-100ps" {
+		t.Fatalf("expected Waveform Latest %s to receive previous preset %q, got %v", latestPV, "std-100ps", got)
+	}
+}
+
+func TestLoadWaveformTrimsSelectedPresetBeforeWriting(t *testing.T) {
+	resetPVRegistryForTest()
+	atomic.StoreInt32(&sequenceFailRate, 0)
+
+	e := newServer()
+	seedLaserPVs()
+
+	const loadedPV = "SI_NL2_LOADED_WAVEFORM"
+	const latestPV = "SI_NL2_LATEST_WAVEFORM"
+	setSeed(loadedPV, "std-100ps")
+	setSeed(latestPV, "older-setup")
+
+	postWaveformCommand(t, e, "NL2", "  ramp-up  ")
+
+	if got := readPV(loadedPV); got != "ramp-up" {
+		t.Fatalf("expected Waveform Preset %s to become trimmed value %q, got %v", loadedPV, "ramp-up", got)
+	}
+	if got := readPV(latestPV); got != "std-100ps" {
+		t.Fatalf("expected Waveform Latest %s to receive previous preset %q, got %v", latestPV, "std-100ps", got)
+	}
+}
+
+func TestLoadWaveformRejectsMissingWaveformName(t *testing.T) {
+	resetPVRegistryForTest()
+
+	_, err := commandPVEffects("CMD_NL2_LOAD_WAVEFORM", "")
+	if err == nil || !strings.Contains(err.Error(), "requires a waveform name") {
+		t.Fatalf("expected empty waveform name to be rejected, got %v", err)
+	}
+
+	_, err = commandPVEffects("CMD_NL2_LOAD_WAVEFORM", 123)
+	if err == nil || !strings.Contains(err.Error(), "requires a waveform name") {
+		t.Fatalf("expected non-string waveform name to be rejected, got %v", err)
+	}
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,6 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -45,12 +44,14 @@
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
       "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
@@ -67,6 +68,7 @@
     },
     "node_modules/@asamuzakjp/dom-selector": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
       "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "license": "MIT",
@@ -83,6 +85,7 @@
     },
     "node_modules/@asamuzakjp/generational-cache": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
       "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
       "dev": true,
       "license": "MIT",
@@ -92,12 +95,14 @@
     },
     "node_modules/@asamuzakjp/nwsapi": {
       "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
@@ -112,6 +117,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
@@ -121,6 +127,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
@@ -151,6 +158,7 @@
     },
     "node_modules/@babel/core/node_modules/json5": {
       "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
@@ -163,6 +171,7 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -172,6 +181,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
@@ -188,6 +198,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
@@ -204,6 +215,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
@@ -213,6 +225,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -222,12 +235,14 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
@@ -237,6 +252,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
@@ -250,6 +266,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
@@ -267,6 +284,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
@@ -276,6 +294,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
@@ -285,6 +304,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
@@ -294,6 +314,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
@@ -307,6 +328,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
@@ -322,6 +344,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.27.1.tgz",
       "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
       "license": "MIT",
       "engines": {
@@ -330,6 +353,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
@@ -344,6 +368,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
@@ -362,6 +387,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
@@ -375,6 +401,7 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
       "license": "MIT",
@@ -384,6 +411,7 @@
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "dev": true,
       "license": "MIT",
@@ -396,6 +424,7 @@
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
       "dev": true,
       "funding": [
@@ -415,6 +444,7 @@
     },
     "node_modules/@csstools/css-calc": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
       "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
       "dev": true,
       "funding": [
@@ -438,6 +468,7 @@
     },
     "node_modules/@csstools/css-color-parser": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
       "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
       "dev": true,
       "funding": [
@@ -465,6 +496,7 @@
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "dev": true,
       "funding": [
@@ -487,6 +519,7 @@
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
       "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
       "dev": true,
       "funding": [
@@ -511,6 +544,7 @@
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "dev": true,
       "funding": [
@@ -530,6 +564,7 @@
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
       "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
       "dev": true,
       "license": "MIT",
@@ -541,6 +576,7 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
       "license": "MIT",
       "optional": true,
@@ -550,6 +586,7 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
@@ -560,6 +597,7 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
       "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
@@ -576,6 +614,7 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
       "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
@@ -592,6 +631,7 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
       "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
@@ -608,6 +648,7 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
       "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
@@ -624,6 +665,7 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
       "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
@@ -640,6 +682,7 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
       "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
@@ -656,6 +699,7 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
       "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
@@ -672,6 +716,7 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
       "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
@@ -688,6 +733,7 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
       "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
@@ -704,6 +750,7 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
       "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
@@ -720,6 +767,7 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
       "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
@@ -736,6 +784,7 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
       "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
@@ -752,6 +801,7 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
       "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
@@ -768,6 +818,7 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
       "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
@@ -784,6 +835,7 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
       "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
@@ -800,6 +852,7 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
       "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
@@ -816,6 +869,7 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
       "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
@@ -832,6 +886,7 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
       "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
@@ -848,6 +903,7 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
       "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
@@ -864,6 +920,7 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
       "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
@@ -880,6 +937,7 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
       "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
@@ -896,6 +954,7 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
       "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
@@ -912,6 +971,7 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
       "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
@@ -928,6 +988,7 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
       "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
@@ -944,6 +1005,7 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
       "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
@@ -960,6 +1022,7 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
       "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
@@ -976,6 +1039,7 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
@@ -994,6 +1058,7 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1006,6 +1071,7 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
@@ -1015,6 +1081,7 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.20.0",
+      "resolved": "https://registry.npmmirror.com/@eslint/config-array/-/config-array-0.20.0.tgz",
       "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1029,6 +1096,7 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmmirror.com/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
       "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1038,6 +1106,7 @@
     },
     "node_modules/@eslint/core": {
       "version": "0.13.0",
+      "resolved": "https://registry.npmmirror.com/@eslint/core/-/core-0.13.0.tgz",
       "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1050,6 +1119,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
       "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
       "license": "MIT",
@@ -1073,6 +1143,7 @@
     },
     "node_modules/@eslint/js": {
       "version": "9.26.0",
+      "resolved": "https://registry.npmmirror.com/@eslint/js/-/js-9.26.0.tgz",
       "integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
       "dev": true,
       "license": "MIT",
@@ -1082,6 +1153,7 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.6",
+      "resolved": "https://registry.npmmirror.com/@eslint/object-schema/-/object-schema-2.1.6.tgz",
       "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1091,6 +1163,7 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.2.8",
+      "resolved": "https://registry.npmmirror.com/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
       "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1104,6 +1177,7 @@
     },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
       "dev": true,
       "license": "MIT",
@@ -1121,6 +1195,7 @@
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/core/-/core-1.7.0.tgz",
       "integrity": "sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==",
       "license": "MIT",
       "dependencies": {
@@ -1129,6 +1204,7 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/dom/-/dom-1.7.0.tgz",
       "integrity": "sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==",
       "license": "MIT",
       "dependencies": {
@@ -1138,6 +1214,7 @@
     },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
       "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
       "license": "MIT",
       "dependencies": {
@@ -1150,11 +1227,13 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.9",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
+      "resolved": "https://registry.npmmirror.com/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1164,6 +1243,7 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.6",
+      "resolved": "https://registry.npmmirror.com/@humanfs/node/-/node-0.16.6.tgz",
       "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1177,6 +1257,7 @@
     },
     "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmmirror.com/@humanwhocodes/retry/-/retry-0.3.1.tgz",
       "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1190,6 +1271,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1203,6 +1285,7 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.2",
+      "resolved": "https://registry.npmmirror.com/@humanwhocodes/retry/-/retry-0.4.2.tgz",
       "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1216,6 +1299,7 @@
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
@@ -1225,6 +1309,7 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
       "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
@@ -1246,6 +1331,7 @@
     },
     "node_modules/@img/sharp-darwin-x64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
       "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
@@ -1267,6 +1353,7 @@
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
       "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
@@ -1282,6 +1369,7 @@
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
       "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
@@ -1297,6 +1385,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
       "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
@@ -1312,6 +1401,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
@@ -1327,6 +1417,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
       "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
       "cpu": [
         "ppc64"
@@ -1342,6 +1433,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
@@ -1357,6 +1449,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
       "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
@@ -1372,6 +1465,7 @@
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
@@ -1387,6 +1481,7 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
       "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
@@ -1402,6 +1497,7 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
       "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
@@ -1417,6 +1513,7 @@
     },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
@@ -1438,6 +1535,7 @@
     },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
       "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
@@ -1459,6 +1557,7 @@
     },
     "node_modules/@img/sharp-linux-ppc64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
@@ -1480,6 +1579,7 @@
     },
     "node_modules/@img/sharp-linux-riscv64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
       "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
       "cpu": [
         "riscv64"
@@ -1501,6 +1601,7 @@
     },
     "node_modules/@img/sharp-linux-s390x": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
@@ -1522,6 +1623,7 @@
     },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
       "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
@@ -1543,6 +1645,7 @@
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
       "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
@@ -1564,6 +1667,7 @@
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
@@ -1585,6 +1689,7 @@
     },
     "node_modules/@img/sharp-wasm32": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
       "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
@@ -1603,6 +1708,7 @@
     },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
       "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
       "cpu": [
         "arm64"
@@ -1621,6 +1727,7 @@
     },
     "node_modules/@img/sharp-win32-ia32": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
       "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
@@ -1639,6 +1746,7 @@
     },
     "node_modules/@img/sharp-win32-x64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
       "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
@@ -1657,6 +1765,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
@@ -1667,6 +1776,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
@@ -1677,6 +1787,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
@@ -1686,12 +1797,14 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
@@ -1702,6 +1815,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.11.0",
+      "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz",
       "integrity": "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==",
       "dev": true,
       "license": "MIT",
@@ -1723,6 +1837,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
       "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
@@ -1732,6 +1847,7 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
       "dev": true,
       "license": "MIT",
@@ -1744,11 +1860,13 @@
     },
     "node_modules/@next/env": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.7.tgz",
       "integrity": "sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.7.tgz",
       "integrity": "sha512-VbS+QgMHqvIDMTIqD2xMBKK1otIpdAUKA8VLHFwR9h6OfU/mOm7w/69nQcvdmI8hCk99Wr2AsGLn/PJ/tMHw1w==",
       "dev": true,
       "license": "MIT",
@@ -1758,6 +1876,7 @@
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.7.tgz",
       "integrity": "sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==",
       "cpu": [
         "arm64"
@@ -1773,6 +1892,7 @@
     },
     "node_modules/@next/swc-darwin-x64": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.7.tgz",
       "integrity": "sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==",
       "cpu": [
         "x64"
@@ -1788,6 +1908,7 @@
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.7.tgz",
       "integrity": "sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==",
       "cpu": [
         "arm64"
@@ -1803,6 +1924,7 @@
     },
     "node_modules/@next/swc-linux-arm64-musl": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.7.tgz",
       "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
       "cpu": [
         "arm64"
@@ -1818,6 +1940,7 @@
     },
     "node_modules/@next/swc-linux-x64-gnu": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.7.tgz",
       "integrity": "sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==",
       "cpu": [
         "x64"
@@ -1833,6 +1956,7 @@
     },
     "node_modules/@next/swc-linux-x64-musl": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.7.tgz",
       "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
       "cpu": [
         "x64"
@@ -1848,6 +1972,7 @@
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.7.tgz",
       "integrity": "sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==",
       "cpu": [
         "arm64"
@@ -1863,6 +1988,7 @@
     },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.7.tgz",
       "integrity": "sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==",
       "cpu": [
         "x64"
@@ -1878,6 +2004,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
@@ -1891,6 +2018,7 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
@@ -1900,6 +2028,7 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
@@ -1913,6 +2042,7 @@
     },
     "node_modules/@nolyfill/is-core-module": {
       "version": "1.0.39",
+      "resolved": "https://registry.npmmirror.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
       "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
       "dev": true,
       "license": "MIT",
@@ -1922,6 +2052,7 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
       "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
@@ -1931,6 +2062,7 @@
     },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/@panva/hkdf/-/hkdf-1.2.1.tgz",
       "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
       "license": "MIT",
       "funding": {
@@ -1939,17 +2071,20 @@
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-arrow/-/react-arrow-1.1.4.tgz",
       "integrity": "sha512-qz+fxrqgNxG0dYew5l7qR3c7wdgRu1XVUHGnGYX7rg5HM4p9SWaRmJwfgR3J0SgyUKayLmzQIun+N6rWRgiRKw==",
       "license": "MIT",
       "dependencies": {
@@ -1972,6 +2107,7 @@
     },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-collection/-/react-collection-1.1.4.tgz",
       "integrity": "sha512-cv4vSf7HttqXilDnAnvINd53OTl1/bjUYVZrkFnA7nwmY9Ob2POUy0WY0sfqBAe1s5FyKsyceQlqiEGPYNTadg==",
       "license": "MIT",
       "dependencies": {
@@ -1997,6 +2133,7 @@
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
       "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
       "license": "MIT",
       "peerDependencies": {
@@ -2011,6 +2148,7 @@
     },
     "node_modules/@radix-ui/react-context": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "license": "MIT",
       "peerDependencies": {
@@ -2025,6 +2163,7 @@
     },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
       "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
       "license": "MIT",
       "peerDependencies": {
@@ -2039,6 +2178,7 @@
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.7.tgz",
       "integrity": "sha512-j5+WBUdhccJsmH5/H0K6RncjDtoALSEr6jbkaZu+bjw6hOPOhHycr6vEUujl+HBK8kjUfWcoCJXxP6e4lUlMZw==",
       "license": "MIT",
       "dependencies": {
@@ -2065,6 +2205,7 @@
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
       "version": "2.1.12",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.12.tgz",
       "integrity": "sha512-VJoMs+BWWE7YhzEQyVwvF9n22Eiyr83HotCVrMQzla/OwRovXCgah7AcaEr4hMNj4gJxSdtIbcHGvmJXOoJVHA==",
       "license": "MIT",
       "dependencies": {
@@ -2093,6 +2234,7 @@
     },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
       "integrity": "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==",
       "license": "MIT",
       "peerDependencies": {
@@ -2107,6 +2249,7 @@
     },
     "node_modules/@radix-ui/react-focus-scope": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.4.tgz",
       "integrity": "sha512-r2annK27lIW5w9Ho5NyQgqs0MmgZSTIKXWpVCJaLC1q2kZrZkcqnmHkCHMEmv8XLvsLlurKMPT+kbKkRkm/xVA==",
       "license": "MIT",
       "dependencies": {
@@ -2131,6 +2274,7 @@
     },
     "node_modules/@radix-ui/react-id": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-id/-/react-id-1.1.1.tgz",
       "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
       "license": "MIT",
       "dependencies": {
@@ -2148,6 +2292,7 @@
     },
     "node_modules/@radix-ui/react-menu": {
       "version": "2.1.12",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-menu/-/react-menu-2.1.12.tgz",
       "integrity": "sha512-+qYq6LfbiGo97Zz9fioX83HCiIYYFNs8zAsVCMQrIakoNYylIzWuoD/anAD3UzvvR6cnswmfRFJFq/zYYq/k7Q==",
       "license": "MIT",
       "dependencies": {
@@ -2187,6 +2332,7 @@
     },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-popper/-/react-popper-1.2.4.tgz",
       "integrity": "sha512-3p2Rgm/a1cK0r/UVkx5F/K9v/EplfjAeIFCGOPYPO4lZ0jtg4iSQXt/YGTSLWaf4x7NG6Z4+uKFcylcTZjeqDA==",
       "license": "MIT",
       "dependencies": {
@@ -2218,6 +2364,7 @@
     },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-portal/-/react-portal-1.1.6.tgz",
       "integrity": "sha512-XmsIl2z1n/TsYFLIdYam2rmFwf9OC/Sh2avkbmVMDuBZIe7hSpM0cYnWPAo7nHOVx8zTuwDZGByfcqLdnzp3Vw==",
       "license": "MIT",
       "dependencies": {
@@ -2241,6 +2388,7 @@
     },
     "node_modules/@radix-ui/react-presence": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
       "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
       "license": "MIT",
       "dependencies": {
@@ -2264,6 +2412,7 @@
     },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-primitive/-/react-primitive-2.1.0.tgz",
       "integrity": "sha512-/J/FhLdK0zVcILOwt5g+dH4KnkonCtkVJsa2G6JmvbbtZfBEI1gMsO3QMjseL4F/SwfAMt1Vc/0XKYKq+xJ1sw==",
       "license": "MIT",
       "dependencies": {
@@ -2286,6 +2435,7 @@
     },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.7.tgz",
       "integrity": "sha512-C6oAg451/fQT3EGbWHbCQjYTtbyjNO1uzQgMzwyivcHT3GKNEmu1q3UuREhN+HzHAVtv3ivMVK08QlC+PkYw9Q==",
       "license": "MIT",
       "dependencies": {
@@ -2316,6 +2466,7 @@
     },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
       "integrity": "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==",
       "license": "MIT",
       "dependencies": {
@@ -2333,6 +2484,7 @@
     },
     "node_modules/@radix-ui/react-tooltip": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-tooltip/-/react-tooltip-1.2.4.tgz",
       "integrity": "sha512-DyW8VVeeMSSLFvAmnVnCwvI3H+1tpJFHT50r+tdOoMse9XqYDBCcyux8u3G2y+LOpt7fPQ6KKH0mhs+ce1+Z5w==",
       "license": "MIT",
       "dependencies": {
@@ -2366,6 +2518,7 @@
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
       "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
       "license": "MIT",
       "peerDependencies": {
@@ -2380,6 +2533,7 @@
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
       "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
       "license": "MIT",
       "dependencies": {
@@ -2398,6 +2552,7 @@
     },
     "node_modules/@radix-ui/react-use-effect-event": {
       "version": "0.0.2",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
       "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
       "license": "MIT",
       "dependencies": {
@@ -2415,6 +2570,7 @@
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
       "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
       "license": "MIT",
       "dependencies": {
@@ -2432,6 +2588,7 @@
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -2446,6 +2603,7 @@
     },
     "node_modules/@radix-ui/react-use-rect": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
       "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
       "license": "MIT",
       "dependencies": {
@@ -2463,6 +2621,7 @@
     },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
       "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
       "license": "MIT",
       "dependencies": {
@@ -2480,6 +2639,7 @@
     },
     "node_modules/@radix-ui/react-visually-hidden": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.0.tgz",
       "integrity": "sha512-rQj0aAWOpCdCMRbI6pLQm8r7S2BM3YhTa0SzOYD55k+hJA8oo9J+H+9wLM9oMlZWOX/wJWPTzfDfmZkf7LvCfg==",
       "license": "MIT",
       "dependencies": {
@@ -2502,11 +2662,13 @@
     },
     "node_modules/@radix-ui/rect": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
       "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
@@ -2523,6 +2685,7 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
       "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
@@ -2539,6 +2702,7 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
       "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
@@ -2555,6 +2719,7 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
       "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
@@ -2571,6 +2736,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
       "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
@@ -2587,6 +2753,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
       "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
@@ -2603,6 +2770,7 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
       "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
@@ -2619,6 +2787,7 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
       "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
@@ -2635,6 +2804,7 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
       "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
@@ -2651,6 +2821,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
       "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
@@ -2667,6 +2838,7 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
       "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
@@ -2683,6 +2855,7 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
       "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
@@ -2699,6 +2872,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
       "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
@@ -2717,6 +2891,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
@@ -2728,6 +2903,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
@@ -2738,6 +2914,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
@@ -2748,6 +2925,7 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
@@ -2766,6 +2944,7 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
       "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
@@ -2782,6 +2961,7 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
       "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
@@ -2798,24 +2978,28 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
+      "resolved": "https://registry.npmmirror.com/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2824,9 +3008,11 @@
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2843,9 +3029,11 @@
     },
     "node_modules/@testing-library/dom/node_modules/ansi-styles": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2855,18 +3043,22 @@
     },
     "node_modules/@testing-library/dom/node_modules/aria-query": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
     },
     "node_modules/@testing-library/dom/node_modules/pretty-format": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2878,12 +3070,15 @@
     },
     "node_modules/@testing-library/dom/node_modules/react-is": {
       "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
@@ -2903,12 +3098,14 @@
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
       "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dev": true,
       "license": "MIT",
@@ -2936,6 +3133,7 @@
     },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "dev": true,
       "license": "MIT",
@@ -2949,6 +3147,7 @@
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dev": true,
       "license": "MIT",
@@ -2959,12 +3158,15 @@
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
@@ -2975,30 +3177,35 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
+      "resolved": "https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
+      "resolved": "https://registry.npmmirror.com/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz",
       "integrity": "sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==",
       "dev": true,
       "license": "MIT",
@@ -3009,12 +3216,14 @@
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
       "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
@@ -3024,6 +3233,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.1.2",
+      "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
       "devOptional": true,
       "license": "MIT",
@@ -3033,6 +3243,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.1.3",
+      "resolved": "https://registry.npmmirror.com/@types/react-dom/-/react-dom-19.1.3.tgz",
       "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
       "devOptional": true,
       "license": "MIT",
@@ -3042,6 +3253,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
       "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
       "dev": true,
       "license": "MIT",
@@ -3070,6 +3282,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
@@ -3079,6 +3292,7 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
@@ -3103,6 +3317,7 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
       "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
       "dev": true,
       "license": "MIT",
@@ -3124,6 +3339,7 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
       "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
       "dev": true,
       "license": "MIT",
@@ -3141,6 +3357,7 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
       "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
       "dev": true,
       "license": "MIT",
@@ -3157,6 +3374,7 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
       "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
       "dev": true,
       "license": "MIT",
@@ -3181,6 +3399,7 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
       "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
       "dev": true,
       "license": "MIT",
@@ -3194,6 +3413,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
       "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
       "dev": true,
       "license": "MIT",
@@ -3221,6 +3441,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
@@ -3230,6 +3451,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
       "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
@@ -3242,6 +3464,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3257,6 +3480,7 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
       "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
       "dev": true,
       "license": "MIT",
@@ -3280,6 +3504,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
       "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
       "dev": true,
       "license": "MIT",
@@ -3297,6 +3522,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3309,6 +3535,7 @@
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmmirror.com/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.7.2.tgz",
       "integrity": "sha512-vxtBno4xvowwNmO/ASL0Y45TpHqmNkAaDtz4Jqb+clmcVSSl8XCG/PNFFkGsXXXS6AMjP+ja/TtNCFFa1QwLRg==",
       "cpu": [
         "arm64"
@@ -3322,6 +3549,7 @@
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.7.2.tgz",
       "integrity": "sha512-qhVa8ozu92C23Hsmv0BF4+5Dyyd5STT1FolV4whNgbY6mj3kA0qsrGPe35zNR3wAN7eFict3s4Rc2dDTPBTuFQ==",
       "cpu": [
         "x64"
@@ -3335,6 +3563,7 @@
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.7.2.tgz",
       "integrity": "sha512-zKKdm2uMXqLFX6Ac7K5ElnnG5VIXbDlFWzg4WJ8CGUedJryM5A3cTgHuGMw1+P5ziV8CRhnSEgOnurTI4vpHpg==",
       "cpu": [
         "x64"
@@ -3348,6 +3577,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.7.2.tgz",
       "integrity": "sha512-8N1z1TbPnHH+iDS/42GJ0bMPLiGK+cUqOhNbMKtWJ4oFGzqSJk/zoXFzcQkgtI63qMcUI7wW1tq2usZQSb2jxw==",
       "cpu": [
         "arm"
@@ -3361,6 +3591,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.7.2.tgz",
       "integrity": "sha512-tjYzI9LcAXR9MYd9rO45m1s0B/6bJNuZ6jeOxo1pq1K6OBuRMMmfyvJYval3s9FPPGmrldYA3mi4gWDlWuTFGA==",
       "cpu": [
         "arm"
@@ -3374,6 +3605,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.7.2.tgz",
       "integrity": "sha512-jon9M7DKRLGZ9VYSkFMflvNqu9hDtOCEnO2QAryFWgT6o6AXU8du56V7YqnaLKr6rAbZBWYsYpikF226v423QA==",
       "cpu": [
         "arm64"
@@ -3387,6 +3619,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.7.2.tgz",
       "integrity": "sha512-c8Cg4/h+kQ63pL43wBNaVMmOjXI/X62wQmru51qjfTvI7kmCy5uHTJvK/9LrF0G8Jdx8r34d019P1DVJmhXQpA==",
       "cpu": [
         "arm64"
@@ -3400,6 +3633,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.7.2.tgz",
       "integrity": "sha512-A+lcwRFyrjeJmv3JJvhz5NbcCkLQL6Mk16kHTNm6/aGNc4FwPHPE4DR9DwuCvCnVHvF5IAd9U4VIs/VvVir5lg==",
       "cpu": [
         "ppc64"
@@ -3413,6 +3647,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.7.2.tgz",
       "integrity": "sha512-hQQ4TJQrSQW8JlPm7tRpXN8OCNP9ez7PajJNjRD1ZTHQAy685OYqPrKjfaMw/8LiHCt8AZ74rfUVHP9vn0N69Q==",
       "cpu": [
         "riscv64"
@@ -3426,6 +3661,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.7.2.tgz",
       "integrity": "sha512-NoAGbiqrxtY8kVooZ24i70CjLDlUFI7nDj3I9y54U94p+3kPxwd2L692YsdLa+cqQ0VoqMWoehDFp21PKRUoIQ==",
       "cpu": [
         "riscv64"
@@ -3439,6 +3675,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.7.2.tgz",
       "integrity": "sha512-KaZByo8xuQZbUhhreBTW+yUnOIHUsv04P8lKjQ5otiGoSJ17ISGYArc+4vKdLEpGaLbemGzr4ZeUbYQQsLWFjA==",
       "cpu": [
         "s390x"
@@ -3452,6 +3689,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.7.2.tgz",
       "integrity": "sha512-dEidzJDubxxhUCBJ/SHSMJD/9q7JkyfBMT77Px1npl4xpg9t0POLvnWywSk66BgZS/b2Hy9Y1yFaoMTFJUe9yg==",
       "cpu": [
         "x64"
@@ -3465,6 +3703,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.7.2.tgz",
       "integrity": "sha512-RvP+Ux3wDjmnZDT4XWFfNBRVG0fMsc+yVzNFUqOflnDfZ9OYujv6nkh+GOr+watwrW4wdp6ASfG/e7bkDradsw==",
       "cpu": [
         "x64"
@@ -3478,6 +3717,7 @@
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.7.2.tgz",
       "integrity": "sha512-y797JBmO9IsvXVRCKDXOxjyAE4+CcZpla2GSoBQ33TVb3ILXuFnMrbR/QQZoauBYeOFuu4w3ifWLw52sdHGz6g==",
       "cpu": [
         "wasm32"
@@ -3494,6 +3734,7 @@
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.7.2.tgz",
       "integrity": "sha512-gtYTh4/VREVSLA+gHrfbWxaMO/00y+34htY7XpioBTy56YN2eBjkPrY1ML1Zys89X3RJDKVaogzwxlM1qU7egg==",
       "cpu": [
         "arm64"
@@ -3507,6 +3748,7 @@
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.7.2.tgz",
       "integrity": "sha512-Ywv20XHvHTDRQs12jd3MY8X5C8KLjDbg/jyaal/QLKx3fAShhJyD4blEANInsjxW3P7isHx1Blt56iUDDJO3jg==",
       "cpu": [
         "ia32"
@@ -3520,6 +3762,7 @@
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.7.2.tgz",
       "integrity": "sha512-friS8NEQfHaDbkThxopGk+LuE5v3iY0StruifjQEt7SLbA46OnfgMO15sOTkbpJkol6RB+1l1TYPXh0sCddpvA==",
       "cpu": [
         "x64"
@@ -3533,6 +3776,7 @@
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
       "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
       "dev": true,
       "license": "MIT",
@@ -3558,12 +3802,14 @@
     },
     "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
@@ -3594,6 +3840,7 @@
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
       "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
@@ -3611,6 +3858,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
       "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
@@ -3623,6 +3871,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
       "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
@@ -3636,6 +3885,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
       "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
@@ -3651,6 +3901,7 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
       "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
@@ -3660,6 +3911,7 @@
     },
     "node_modules/@vitest/ui": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
       "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
@@ -3681,6 +3933,7 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
       "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
@@ -3695,6 +3948,7 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "dev": true,
       "license": "MIT",
@@ -3708,6 +3962,7 @@
     },
     "node_modules/acorn": {
       "version": "8.14.1",
+      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
@@ -3720,6 +3975,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmmirror.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
@@ -3729,6 +3985,7 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
@@ -3745,15 +4002,18 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
@@ -3769,12 +4029,14 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/aria-hidden/-/aria-hidden-1.2.4.tgz",
       "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
       "license": "MIT",
       "dependencies": {
@@ -3786,6 +4048,7 @@
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmmirror.com/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3795,6 +4058,7 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "license": "MIT",
@@ -3811,6 +4075,7 @@
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
       "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
       "dev": true,
       "license": "MIT",
@@ -3833,6 +4098,7 @@
     },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmmirror.com/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
       "license": "MIT",
@@ -3853,6 +4119,7 @@
     },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.6",
+      "resolved": "https://registry.npmmirror.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
       "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
       "dev": true,
       "license": "MIT",
@@ -3874,6 +4141,7 @@
     },
     "node_modules/array.prototype.flat": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
       "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
       "license": "MIT",
@@ -3892,6 +4160,7 @@
     },
     "node_modules/array.prototype.flatmap": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
       "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
       "license": "MIT",
@@ -3910,6 +4179,7 @@
     },
     "node_modules/array.prototype.tosorted": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
       "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
       "license": "MIT",
@@ -3926,6 +4196,7 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
       "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "license": "MIT",
@@ -3947,6 +4218,7 @@
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
@@ -3956,12 +4228,14 @@
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
+      "resolved": "https://registry.npmmirror.com/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ast-v8-to-istanbul": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
       "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
       "dev": true,
       "license": "MIT",
@@ -3973,12 +4247,14 @@
     },
     "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
       "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/async-function/-/async-function-1.0.0.tgz",
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true,
       "license": "MIT",
@@ -3988,6 +4264,7 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "license": "MIT",
@@ -4003,6 +4280,7 @@
     },
     "node_modules/axe-core": {
       "version": "4.10.3",
+      "resolved": "https://registry.npmmirror.com/axe-core/-/axe-core-4.10.3.tgz",
       "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
       "dev": true,
       "license": "MPL-2.0",
@@ -4012,6 +4290,7 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4021,12 +4300,14 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.34",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
       "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
       "license": "Apache-2.0",
       "bin": {
@@ -4038,6 +4319,7 @@
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
       "license": "MIT",
@@ -4047,6 +4329,7 @@
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/body-parser/-/body-parser-2.2.0.tgz",
       "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
       "dev": true,
       "license": "MIT",
@@ -4067,6 +4350,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
@@ -4077,6 +4361,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
@@ -4089,6 +4374,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
@@ -4122,11 +4408,13 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
       "license": "MIT",
@@ -4136,6 +4424,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
@@ -4154,6 +4443,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
@@ -4167,6 +4457,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
@@ -4183,6 +4474,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
@@ -4192,6 +4484,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
       "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "funding": [
         {
@@ -4211,6 +4504,7 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
@@ -4220,6 +4514,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
@@ -4236,11 +4531,13 @@
     },
     "node_modules/client-only": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmmirror.com/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
     "node_modules/clsx": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
@@ -4249,6 +4546,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
@@ -4261,18 +4559,21 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmmirror.com/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/content-disposition/-/content-disposition-1.0.0.tgz",
       "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
       "dev": true,
       "license": "MIT",
@@ -4285,6 +4586,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
       "license": "MIT",
@@ -4294,12 +4596,14 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
+      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
@@ -4308,6 +4612,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "dev": true,
       "license": "MIT",
@@ -4317,6 +4622,7 @@
     },
     "node_modules/cors": {
       "version": "2.8.5",
+      "resolved": "https://registry.npmmirror.com/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
       "license": "MIT",
@@ -4330,6 +4636,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -4344,6 +4651,7 @@
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
@@ -4357,24 +4665,28 @@
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
       "license": "MIT",
@@ -4388,6 +4700,7 @@
     },
     "node_modules/data-urls/node_modules/tr46": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
@@ -4400,6 +4713,7 @@
     },
     "node_modules/data-urls/node_modules/webidl-conversions": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4409,6 +4723,7 @@
     },
     "node_modules/data-urls/node_modules/whatwg-url": {
       "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
@@ -4423,6 +4738,7 @@
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
       "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "license": "MIT",
@@ -4440,6 +4756,7 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
       "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "license": "MIT",
@@ -4457,6 +4774,7 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
       "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
       "license": "MIT",
@@ -4474,6 +4792,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -4491,18 +4810,21 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmmirror.com/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
@@ -4520,6 +4842,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
       "license": "MIT",
@@ -4537,6 +4860,7 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
       "license": "MIT",
@@ -4546,15 +4870,18 @@
     },
     "node_modules/dequal": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -4564,11 +4891,13 @@
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -4581,12 +4910,15 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
@@ -4601,6 +4933,7 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmmirror.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -4609,24 +4942,28 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.368",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
       "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
       "license": "MIT",
@@ -4636,6 +4973,7 @@
     },
     "node_modules/entities": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4648,6 +4986,7 @@
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
       "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
@@ -4716,6 +5055,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
@@ -4725,6 +5065,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
@@ -4734,6 +5075,7 @@
     },
     "node_modules/es-iterator-helpers": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
       "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
       "dev": true,
       "license": "MIT",
@@ -4761,12 +5103,14 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
@@ -4779,6 +5123,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
@@ -4794,6 +5139,7 @@
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
       "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
       "dev": true,
       "license": "MIT",
@@ -4806,6 +5152,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
       "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
       "license": "MIT",
@@ -4823,6 +5170,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
@@ -4864,6 +5212,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
@@ -4873,12 +5222,14 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
@@ -4891,6 +5242,7 @@
     },
     "node_modules/eslint": {
       "version": "9.26.0",
+      "resolved": "https://registry.npmmirror.com/eslint/-/eslint-9.26.0.tgz",
       "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "dev": true,
       "license": "MIT",
@@ -4953,6 +5305,7 @@
     },
     "node_modules/eslint-config-next": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.7.tgz",
       "integrity": "sha512-CQ2aNXkrsjaGA2oJBE1LYnlRdphIAQE9ZQfX9hSv1PNGPyiOMSaVeBfTIO29QxYz+ij/hZudK0cfpCG1HXWstg==",
       "dev": true,
       "license": "MIT",
@@ -4979,6 +5332,7 @@
     },
     "node_modules/eslint-config-next/node_modules/globals": {
       "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
       "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
       "dev": true,
       "license": "MIT",
@@ -4991,6 +5345,7 @@
     },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
+      "resolved": "https://registry.npmmirror.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
       "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
       "dev": true,
       "license": "MIT",
@@ -5002,6 +5357,7 @@
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
@@ -5011,6 +5367,7 @@
     },
     "node_modules/eslint-import-resolver-typescript": {
       "version": "3.10.1",
+      "resolved": "https://registry.npmmirror.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
       "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
       "dev": true,
       "license": "ISC",
@@ -5045,6 +5402,7 @@
     },
     "node_modules/eslint-module-utils": {
       "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
       "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
       "dev": true,
       "license": "MIT",
@@ -5062,6 +5420,7 @@
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
@@ -5071,6 +5430,7 @@
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
@@ -5104,6 +5464,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
@@ -5113,6 +5474,7 @@
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -5122,6 +5484,7 @@
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
+      "resolved": "https://registry.npmmirror.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
@@ -5151,6 +5514,7 @@
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
+      "resolved": "https://registry.npmmirror.com/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
@@ -5183,6 +5547,7 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
       "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
@@ -5202,6 +5567,7 @@
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
       "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmmirror.com/resolve/-/resolve-2.0.0-next.5.tgz",
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dev": true,
       "license": "MIT",
@@ -5219,6 +5585,7 @@
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -5228,6 +5595,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "8.3.0",
+      "resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-8.3.0.tgz",
       "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -5244,6 +5612,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -5256,6 +5625,7 @@
     },
     "node_modules/eslint/node_modules/zod": {
       "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
@@ -5265,6 +5635,7 @@
     },
     "node_modules/espree": {
       "version": "10.3.0",
+      "resolved": "https://registry.npmmirror.com/espree/-/espree-10.3.0.tgz",
       "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -5282,6 +5653,7 @@
     },
     "node_modules/esquery": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -5294,6 +5666,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -5306,6 +5679,7 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -5315,6 +5689,7 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
@@ -5324,6 +5699,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -5333,6 +5709,7 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
+      "resolved": "https://registry.npmmirror.com/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
       "license": "MIT",
@@ -5342,6 +5719,7 @@
     },
     "node_modules/eventsource": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/eventsource/-/eventsource-3.0.6.tgz",
       "integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
       "dev": true,
       "license": "MIT",
@@ -5354,6 +5732,7 @@
     },
     "node_modules/eventsource-parser": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
       "integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
       "dev": true,
       "license": "MIT",
@@ -5363,6 +5742,7 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -5372,6 +5752,7 @@
     },
     "node_modules/express": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
@@ -5414,6 +5795,7 @@
     },
     "node_modules/express-rate-limit": {
       "version": "7.5.0",
+      "resolved": "https://registry.npmmirror.com/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
       "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
       "dev": true,
       "license": "MIT",
@@ -5429,12 +5811,14 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "license": "MIT",
@@ -5451,6 +5835,7 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
@@ -5463,18 +5848,21 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmmirror.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
@@ -5484,12 +5872,14 @@
     },
     "node_modules/fflate": {
       "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
@@ -5502,6 +5892,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
@@ -5514,6 +5905,7 @@
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/finalhandler/-/finalhandler-2.1.0.tgz",
       "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
       "dev": true,
       "license": "MIT",
@@ -5531,6 +5923,7 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
@@ -5547,6 +5940,7 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
@@ -5560,12 +5954,14 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
+      "resolved": "https://registry.npmmirror.com/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
@@ -5581,6 +5977,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
       "license": "MIT",
@@ -5590,6 +5987,7 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "dev": true,
       "license": "MIT",
@@ -5599,6 +5997,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -5613,6 +6012,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
@@ -5622,6 +6022,7 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
+      "resolved": "https://registry.npmmirror.com/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
       "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
       "license": "MIT",
@@ -5642,6 +6043,7 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
       "license": "MIT",
@@ -5651,6 +6053,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
@@ -5660,6 +6063,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
@@ -5684,6 +6088,7 @@
     },
     "node_modules/get-nonce": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "license": "MIT",
       "engines": {
@@ -5692,6 +6097,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
@@ -5705,6 +6111,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
       "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
       "license": "MIT",
@@ -5722,6 +6129,7 @@
     },
     "node_modules/get-tsconfig": {
       "version": "4.10.0",
+      "resolved": "https://registry.npmmirror.com/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
       "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
       "dev": true,
       "license": "MIT",
@@ -5734,6 +6142,7 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
@@ -5746,6 +6155,7 @@
     },
     "node_modules/globals": {
       "version": "14.0.0",
+      "resolved": "https://registry.npmmirror.com/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
@@ -5758,6 +6168,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "license": "MIT",
@@ -5774,6 +6185,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
@@ -5786,6 +6198,7 @@
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/has-bigints/-/has-bigints-1.1.0.tgz",
       "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
       "license": "MIT",
@@ -5798,6 +6211,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
@@ -5807,6 +6221,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
@@ -5819,6 +6234,7 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/has-proto/-/has-proto-1.2.0.tgz",
       "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
       "license": "MIT",
@@ -5834,6 +6250,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
@@ -5846,6 +6263,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
@@ -5861,6 +6279,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
@@ -5873,12 +6292,14 @@
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
       "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
       "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
       "dev": true,
       "license": "MIT",
@@ -5888,6 +6309,7 @@
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
@@ -5900,12 +6322,14 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
       "license": "MIT",
@@ -5922,6 +6346,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "license": "MIT",
@@ -5934,6 +6359,7 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmmirror.com/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
@@ -5943,6 +6369,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
@@ -5959,6 +6386,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmmirror.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
@@ -5968,6 +6396,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true,
       "license": "MIT",
@@ -5977,12 +6406,14 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
@@ -5997,6 +6428,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
       "license": "MIT",
@@ -6006,6 +6438,7 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "license": "MIT",
@@ -6023,6 +6456,7 @@
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/is-async-function/-/is-async-function-2.1.1.tgz",
       "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
       "license": "MIT",
@@ -6042,6 +6476,7 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
       "license": "MIT",
@@ -6057,6 +6492,7 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
       "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "license": "MIT",
@@ -6073,6 +6509,7 @@
     },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/is-bun-module/-/is-bun-module-2.0.0.tgz",
       "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
       "dev": true,
       "license": "MIT",
@@ -6082,6 +6519,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmmirror.com/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
@@ -6094,6 +6532,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
+      "resolved": "https://registry.npmmirror.com/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
@@ -6109,6 +6548,7 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/is-data-view/-/is-data-view-1.0.2.tgz",
       "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "license": "MIT",
@@ -6126,6 +6566,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "license": "MIT",
@@ -6142,6 +6583,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
@@ -6151,6 +6593,7 @@
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
       "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
       "license": "MIT",
@@ -6166,6 +6609,7 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/is-generator-function/-/is-generator-function-1.1.0.tgz",
       "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
       "dev": true,
       "license": "MIT",
@@ -6184,6 +6628,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
@@ -6196,6 +6641,7 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
@@ -6208,6 +6654,7 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
       "license": "MIT",
@@ -6220,6 +6667,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
@@ -6229,6 +6677,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "license": "MIT",
@@ -6245,18 +6694,21 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
@@ -6275,6 +6727,7 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
       "license": "MIT",
@@ -6287,6 +6740,7 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "license": "MIT",
@@ -6302,6 +6756,7 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "license": "MIT",
@@ -6318,6 +6773,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "license": "MIT",
@@ -6335,6 +6791,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
+      "resolved": "https://registry.npmmirror.com/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
@@ -6350,6 +6807,7 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
       "license": "MIT",
@@ -6362,6 +6820,7 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/is-weakref/-/is-weakref-1.1.1.tgz",
       "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "license": "MIT",
@@ -6377,6 +6836,7 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/is-weakset/-/is-weakset-2.0.4.tgz",
       "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "license": "MIT",
@@ -6393,18 +6853,21 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6414,6 +6877,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6428,6 +6892,7 @@
     },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6441,6 +6906,7 @@
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmmirror.com/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
       "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
       "license": "MIT",
@@ -6458,6 +6924,7 @@
     },
     "node_modules/jose": {
       "version": "4.15.9",
+      "resolved": "https://registry.npmmirror.com/jose/-/jose-4.15.9.tgz",
       "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
       "license": "MIT",
       "funding": {
@@ -6466,12 +6933,14 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
@@ -6484,6 +6953,7 @@
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
@@ -6524,6 +6994,7 @@
     },
     "node_modules/jsdom/node_modules/lru-cache": {
       "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -6533,6 +7004,7 @@
     },
     "node_modules/jsdom/node_modules/tr46": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
@@ -6545,6 +7017,7 @@
     },
     "node_modules/jsdom/node_modules/webidl-conversions": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -6554,6 +7027,7 @@
     },
     "node_modules/jsdom/node_modules/whatwg-url": {
       "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
@@ -6568,6 +7042,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
@@ -6580,24 +7055,28 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/json5/-/json5-1.0.2.tgz",
       "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "license": "MIT",
@@ -6610,6 +7089,7 @@
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
+      "resolved": "https://registry.npmmirror.com/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
       "license": "MIT",
       "dependencies": {
@@ -6631,6 +7111,7 @@
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
+      "resolved": "https://registry.npmmirror.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
       "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "license": "MIT",
@@ -6646,6 +7127,7 @@
     },
     "node_modules/jwa": {
       "version": "1.4.2",
+      "resolved": "https://registry.npmmirror.com/jwa/-/jwa-1.4.2.tgz",
       "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
       "license": "MIT",
       "dependencies": {
@@ -6656,6 +7138,7 @@
     },
     "node_modules/jws": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmmirror.com/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "license": "MIT",
       "dependencies": {
@@ -6665,6 +7148,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
+      "resolved": "https://registry.npmmirror.com/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
@@ -6674,12 +7158,14 @@
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
+      "resolved": "https://registry.npmmirror.com/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
       "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/language-tags": {
       "version": "1.0.9",
+      "resolved": "https://registry.npmmirror.com/language-tags/-/language-tags-1.0.9.tgz",
       "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
       "license": "MIT",
@@ -6692,6 +7178,7 @@
     },
     "node_modules/ldap-authentication": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/ldap-authentication/-/ldap-authentication-4.0.4.tgz",
       "integrity": "sha512-dcI/CAfbgJ+Nmr3MDPMGMBSQscqBJ/JyNC+JNuhtfLmcMen7voP82DYBERv2+LEs+W9+nCGU7AkgkydFUS1ugg==",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6703,6 +7190,7 @@
     },
     "node_modules/ldapts": {
       "version": "8.1.8",
+      "resolved": "https://registry.npmjs.org/ldapts/-/ldapts-8.1.8.tgz",
       "integrity": "sha512-Wpdvo+/0DREIynYf2he2efHtjptr5zD7dpesSkZWJqfQdMEgSTytEIsSZVuoDSiiE1+SpXf3emZ7ewxGBTo7Pw==",
       "license": "MIT",
       "dependencies": {
@@ -6714,6 +7202,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmmirror.com/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
@@ -6727,6 +7216,7 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -6756,6 +7246,7 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -6776,6 +7267,7 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -6796,6 +7288,7 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -6816,6 +7309,7 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -6836,6 +7330,7 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -6856,6 +7351,7 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
@@ -6876,6 +7372,7 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
@@ -6896,6 +7393,7 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
@@ -6916,6 +7414,7 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
@@ -6936,6 +7435,7 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -6956,6 +7456,7 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -6976,6 +7477,7 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
@@ -6991,47 +7493,56 @@
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmmirror.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
+      "resolved": "https://registry.npmmirror.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "resolved": "https://registry.npmmirror.com/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "license": "MIT",
@@ -7044,12 +7555,14 @@
     },
     "node_modules/loupe": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
       "dependencies": {
@@ -7061,15 +7574,18 @@
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
@@ -7079,6 +7595,7 @@
     },
     "node_modules/magicast": {
       "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
       "dev": true,
       "license": "MIT",
@@ -7090,6 +7607,7 @@
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "license": "MIT",
@@ -7105,6 +7623,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
@@ -7114,12 +7633,14 @@
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "dev": true,
       "license": "MIT",
@@ -7129,6 +7650,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "dev": true,
       "license": "MIT",
@@ -7141,6 +7663,7 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
@@ -7150,6 +7673,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
@@ -7163,6 +7687,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
@@ -7172,6 +7697,7 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-3.0.1.tgz",
       "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
       "dev": true,
       "license": "MIT",
@@ -7184,6 +7710,7 @@
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
       "license": "MIT",
@@ -7193,6 +7720,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
@@ -7205,6 +7733,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmmirror.com/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
@@ -7214,6 +7743,7 @@
     },
     "node_modules/mock-socket": {
       "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
       "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
       "dev": true,
       "license": "MIT",
@@ -7223,6 +7753,7 @@
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
       "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
       "dev": true,
       "license": "MIT",
@@ -7232,11 +7763,13 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
+      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
@@ -7254,6 +7787,7 @@
     },
     "node_modules/napi-postinstall": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmmirror.com/napi-postinstall/-/napi-postinstall-0.2.3.tgz",
       "integrity": "sha512-Mi7JISo/4Ij2tDZ2xBE2WH+/KvVlkhA6juEjpEeRAVPNCpN3nxJo/5FhDNKgBcdmcmhaH6JjgST4xY/23ZYK0w==",
       "dev": true,
       "license": "MIT",
@@ -7269,12 +7803,14 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "dev": true,
       "license": "MIT",
@@ -7284,6 +7820,7 @@
     },
     "node_modules/next": {
       "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.7.tgz",
       "integrity": "sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==",
       "license": "MIT",
       "dependencies": {
@@ -7336,6 +7873,7 @@
     },
     "node_modules/next-auth": {
       "version": "4.24.14",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.14.tgz",
       "integrity": "sha512-YRz6xFDXKUwiXSMMChbrBEWyFktZ1qZXEgeSHQQ3nsy08B4c/xLk6REeutRsIFwkjY/1+ShHnu07DN3JeJguig==",
       "license": "ISC",
       "dependencies": {
@@ -7367,6 +7905,7 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
       "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
       "license": "MIT",
@@ -7376,11 +7915,13 @@
     },
     "node_modules/oauth": {
       "version": "0.9.15",
+      "resolved": "https://registry.npmmirror.com/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
       "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "license": "MIT",
@@ -7390,6 +7931,7 @@
     },
     "node_modules/object-hash": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
       "license": "MIT",
       "engines": {
@@ -7398,6 +7940,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
@@ -7410,6 +7953,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
       "license": "MIT",
@@ -7419,6 +7963,7 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
+      "resolved": "https://registry.npmmirror.com/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "license": "MIT",
@@ -7439,6 +7984,7 @@
     },
     "node_modules/object.entries": {
       "version": "1.1.9",
+      "resolved": "https://registry.npmmirror.com/object.entries/-/object.entries-1.1.9.tgz",
       "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "license": "MIT",
@@ -7454,6 +8000,7 @@
     },
     "node_modules/object.fromentries": {
       "version": "2.0.8",
+      "resolved": "https://registry.npmmirror.com/object.fromentries/-/object.fromentries-2.0.8.tgz",
       "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
       "license": "MIT",
@@ -7472,6 +8019,7 @@
     },
     "node_modules/object.groupby": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/object.groupby/-/object.groupby-1.0.3.tgz",
       "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
       "dev": true,
       "license": "MIT",
@@ -7486,6 +8034,7 @@
     },
     "node_modules/object.values": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/object.values/-/object.values-1.2.1.tgz",
       "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
       "license": "MIT",
@@ -7504,6 +8053,7 @@
     },
     "node_modules/obug": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
       "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
       "dev": true,
       "funding": [
@@ -7514,6 +8064,7 @@
     },
     "node_modules/oidc-token-hash": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmmirror.com/oidc-token-hash/-/oidc-token-hash-5.1.0.tgz",
       "integrity": "sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==",
       "license": "MIT",
       "engines": {
@@ -7522,6 +8073,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmmirror.com/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
       "license": "MIT",
@@ -7534,6 +8086,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
@@ -7543,6 +8096,7 @@
     },
     "node_modules/openid-client": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmmirror.com/openid-client/-/openid-client-5.7.1.tgz",
       "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
       "license": "MIT",
       "dependencies": {
@@ -7557,6 +8111,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
+      "resolved": "https://registry.npmmirror.com/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
@@ -7574,6 +8129,7 @@
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/own-keys/-/own-keys-1.0.1.tgz",
       "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
       "dev": true,
       "license": "MIT",
@@ -7591,6 +8147,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -7606,6 +8163,7 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
@@ -7621,6 +8179,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
@@ -7633,6 +8192,7 @@
     },
     "node_modules/parse5": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "dev": true,
       "license": "MIT",
@@ -7645,6 +8205,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
       "license": "MIT",
@@ -7654,6 +8215,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
@@ -7663,6 +8225,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -7672,12 +8235,14 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
+      "resolved": "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
       "dev": true,
       "license": "MIT",
@@ -7687,17 +8252,20 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
@@ -7710,6 +8278,7 @@
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
       "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
       "dev": true,
       "license": "MIT",
@@ -7719,6 +8288,7 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
@@ -7728,6 +8298,7 @@
     },
     "node_modules/postcss": {
       "version": "8.4.31",
+      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
@@ -7755,6 +8326,7 @@
     },
     "node_modules/preact": {
       "version": "10.26.6",
+      "resolved": "https://registry.npmmirror.com/preact/-/preact-10.26.6.tgz",
       "integrity": "sha512-5SRRBinwpwkaD+OqlBDeITlRgvd8I8QlxHJw9AxSdMNV6O+LodN9nUyYGpSF7sadHjs6RzeFShMexC6DbtWr9g==",
       "license": "MIT",
       "funding": {
@@ -7764,6 +8336,7 @@
     },
     "node_modules/preact-render-to-string": {
       "version": "5.2.6",
+      "resolved": "https://registry.npmmirror.com/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
       "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
       "license": "MIT",
       "dependencies": {
@@ -7775,6 +8348,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
@@ -7784,6 +8358,7 @@
     },
     "node_modules/prettier": {
       "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
@@ -7799,11 +8374,13 @@
     },
     "node_modules/pretty-format": {
       "version": "3.8.0",
+      "resolved": "https://registry.npmmirror.com/pretty-format/-/pretty-format-3.8.0.tgz",
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
       "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
+      "resolved": "https://registry.npmmirror.com/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dev": true,
       "license": "MIT",
@@ -7815,6 +8392,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
       "license": "MIT",
@@ -7828,6 +8406,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
@@ -7837,6 +8416,7 @@
     },
     "node_modules/qs": {
       "version": "6.14.0",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -7852,6 +8432,7 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
@@ -7872,6 +8453,7 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
       "license": "MIT",
@@ -7881,6 +8463,7 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/raw-body/-/raw-body-3.0.0.tgz",
       "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
       "dev": true,
       "license": "MIT",
@@ -7896,6 +8479,7 @@
     },
     "node_modules/react": {
       "version": "19.1.0",
+      "resolved": "https://registry.npmmirror.com/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
       "engines": {
@@ -7904,6 +8488,7 @@
     },
     "node_modules/react-dom": {
       "version": "19.1.0",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
       "dependencies": {
@@ -7915,12 +8500,14 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
+      "resolved": "https://registry.npmmirror.com/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmmirror.com/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
       "integrity": "sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==",
       "license": "MIT",
       "dependencies": {
@@ -7945,6 +8532,7 @@
     },
     "node_modules/react-remove-scroll-bar": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmmirror.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
       "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "license": "MIT",
       "dependencies": {
@@ -7966,6 +8554,7 @@
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
+      "resolved": "https://registry.npmmirror.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
       "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "license": "MIT",
       "dependencies": {
@@ -7987,6 +8576,7 @@
     },
     "node_modules/redent": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "dev": true,
       "license": "MIT",
@@ -8000,6 +8590,7 @@
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmmirror.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
       "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
       "license": "MIT",
@@ -8022,6 +8613,7 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
+      "resolved": "https://registry.npmmirror.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "license": "MIT",
@@ -8042,6 +8634,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
@@ -8051,6 +8644,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.10",
+      "resolved": "https://registry.npmmirror.com/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dev": true,
       "license": "MIT",
@@ -8071,6 +8665,7 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
@@ -8080,6 +8675,7 @@
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
@@ -8089,6 +8685,7 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
@@ -8099,6 +8696,7 @@
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
       "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
@@ -8132,6 +8730,7 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "dev": true,
       "license": "MIT",
@@ -8148,6 +8747,7 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
@@ -8171,6 +8771,7 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
       "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
       "license": "MIT",
@@ -8190,6 +8791,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
@@ -8209,6 +8811,7 @@
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
       "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
       "license": "MIT",
@@ -8225,6 +8828,7 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "license": "MIT",
@@ -8242,12 +8846,14 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "license": "ISC",
@@ -8260,11 +8866,13 @@
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
+      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
       "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "license": "ISC",
       "bin": {
@@ -8276,6 +8884,7 @@
     },
     "node_modules/send": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/send/-/send-1.2.0.tgz",
       "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
       "dev": true,
       "license": "MIT",
@@ -8298,6 +8907,7 @@
     },
     "node_modules/serve-static": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
       "dev": true,
       "license": "MIT",
@@ -8313,11 +8923,13 @@
     },
     "node_modules/server-only": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "license": "MIT",
@@ -8335,6 +8947,7 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
       "license": "MIT",
@@ -8350,6 +8963,7 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/set-proto/-/set-proto-1.0.0.tgz",
       "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
       "dev": true,
       "license": "MIT",
@@ -8364,12 +8978,14 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -8414,6 +9030,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -8426,6 +9043,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -8435,6 +9053,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
@@ -8454,6 +9073,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
       "license": "MIT",
@@ -8470,6 +9090,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "license": "MIT",
@@ -8488,6 +9109,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "license": "MIT",
@@ -8507,12 +9129,14 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/sirv": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
       "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
       "dev": true,
       "license": "MIT",
@@ -8527,6 +9151,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -8535,18 +9160,21 @@
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
+      "resolved": "https://registry.npmmirror.com/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true,
       "license": "MIT",
@@ -8556,12 +9184,14 @@
     },
     "node_modules/std-env": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
       "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
       "license": "MIT",
@@ -8575,11 +9205,13 @@
     },
     "node_modules/strict-event-emitter-types": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
       "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
       "license": "ISC"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
       "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
       "dev": true,
       "license": "MIT",
@@ -8594,6 +9226,7 @@
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
+      "resolved": "https://registry.npmmirror.com/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
       "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
       "license": "MIT",
@@ -8621,6 +9254,7 @@
     },
     "node_modules/string.prototype.repeat": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
       "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
       "license": "MIT",
@@ -8631,6 +9265,7 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
+      "resolved": "https://registry.npmmirror.com/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
       "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
       "license": "MIT",
@@ -8652,6 +9287,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.9",
+      "resolved": "https://registry.npmmirror.com/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
       "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
       "license": "MIT",
@@ -8670,6 +9306,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
       "license": "MIT",
@@ -8687,6 +9324,7 @@
     },
     "node_modules/strip-bom": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
@@ -8696,6 +9334,7 @@
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "dev": true,
       "license": "MIT",
@@ -8708,6 +9347,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
@@ -8720,6 +9360,7 @@
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
+      "resolved": "https://registry.npmmirror.com/styled-jsx/-/styled-jsx-5.1.6.tgz",
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "license": "MIT",
       "dependencies": {
@@ -8742,6 +9383,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
@@ -8754,6 +9396,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
@@ -8766,18 +9409,21 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
       "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
@@ -8787,6 +9433,7 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
@@ -8803,6 +9450,7 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -8820,6 +9468,7 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -8832,6 +9481,7 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
@@ -8841,6 +9491,7 @@
     },
     "node_modules/tldts": {
       "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
       "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
       "dev": true,
       "license": "MIT",
@@ -8853,12 +9504,14 @@
     },
     "node_modules/tldts-core": {
       "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
       "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
@@ -8871,6 +9524,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
       "license": "MIT",
@@ -8880,6 +9534,7 @@
     },
     "node_modules/totalist": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
       "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
       "dev": true,
       "license": "MIT",
@@ -8889,6 +9544,7 @@
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -8901,6 +9557,7 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
@@ -8913,6 +9570,7 @@
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
+      "resolved": "https://registry.npmmirror.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
       "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "license": "MIT",
@@ -8925,11 +9583,13 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
@@ -8948,6 +9608,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
@@ -8960,6 +9621,7 @@
     },
     "node_modules/type-is": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "dev": true,
       "license": "MIT",
@@ -8974,6 +9636,7 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "license": "MIT",
@@ -8988,6 +9651,7 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
       "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
       "license": "MIT",
@@ -9007,6 +9671,7 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
       "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
       "license": "MIT",
@@ -9028,6 +9693,7 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmmirror.com/typed-array-length/-/typed-array-length-1.0.7.tgz",
       "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
       "license": "MIT",
@@ -9048,6 +9714,7 @@
     },
     "node_modules/typescript": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -9061,6 +9728,7 @@
     },
     "node_modules/typescript-eslint": {
       "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
       "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
       "dev": true,
       "license": "MIT",
@@ -9084,6 +9752,7 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
       "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "license": "MIT",
@@ -9102,6 +9771,7 @@
     },
     "node_modules/undici": {
       "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
       "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
@@ -9111,12 +9781,14 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
       "license": "MIT",
@@ -9126,6 +9798,7 @@
     },
     "node_modules/unrs-resolver": {
       "version": "1.7.2",
+      "resolved": "https://registry.npmmirror.com/unrs-resolver/-/unrs-resolver-1.7.2.tgz",
       "integrity": "sha512-BBKpaylOW8KbHsu378Zky/dGh4ckT/4NW/0SHRABdqRLcQJ2dAOjDo9g97p04sWflm0kqPqpUatxReNV/dqI5A==",
       "dev": true,
       "hasInstallScript": true,
@@ -9158,6 +9831,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
@@ -9188,6 +9862,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -9197,6 +9872,7 @@
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
       "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "license": "MIT",
       "dependencies": {
@@ -9217,6 +9893,7 @@
     },
     "node_modules/use-sidecar": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/use-sidecar/-/use-sidecar-1.1.3.tgz",
       "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
       "license": "MIT",
       "dependencies": {
@@ -9238,6 +9915,7 @@
     },
     "node_modules/uuid": {
       "version": "8.3.2",
+      "resolved": "https://registry.npmmirror.com/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
       "bin": {
@@ -9246,6 +9924,7 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
       "license": "MIT",
@@ -9255,6 +9934,7 @@
     },
     "node_modules/vite": {
       "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
@@ -9332,6 +10012,7 @@
     },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -9344,6 +10025,7 @@
     },
     "node_modules/vite/node_modules/postcss": {
       "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
       "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
@@ -9372,6 +10054,7 @@
     },
     "node_modules/vitest": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
@@ -9461,6 +10144,7 @@
     },
     "node_modules/vitest-websocket-mock": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/vitest-websocket-mock/-/vitest-websocket-mock-0.5.0.tgz",
       "integrity": "sha512-vzBWeuF/kD/OCOFzB7WAclb7PxfI105qPkZtdOkPMwZdilBskQjJL4l319JtPtmeovDU7ZVhO3hTfGPjM4txQQ==",
       "dev": true,
       "license": "MIT",
@@ -9474,6 +10158,7 @@
     },
     "node_modules/vitest-websocket-mock/node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
       "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "dev": true,
       "license": "MIT",
@@ -9486,6 +10171,7 @@
     },
     "node_modules/vitest-websocket-mock/node_modules/@vitest/utils": {
       "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
       "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dev": true,
       "license": "MIT",
@@ -9500,6 +10186,7 @@
     },
     "node_modules/vitest-websocket-mock/node_modules/tinyrainbow": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
@@ -9509,6 +10196,7 @@
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
       "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
@@ -9535,6 +10223,7 @@
     },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -9547,6 +10236,7 @@
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
@@ -9559,6 +10249,7 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
@@ -9568,6 +10259,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -9583,6 +10275,7 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "license": "MIT",
@@ -9602,6 +10295,7 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
       "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
       "license": "MIT",
@@ -9629,6 +10323,7 @@
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
       "license": "MIT",
@@ -9647,6 +10342,7 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
+      "resolved": "https://registry.npmmirror.com/which-typed-array/-/which-typed-array-1.1.19.tgz",
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
       "license": "MIT",
@@ -9668,6 +10364,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
@@ -9684,6 +10381,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmmirror.com/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
@@ -9693,12 +10391,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
@@ -9708,17 +10408,20 @@
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
@@ -9733,6 +10436,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
@@ -9745,6 +10449,7 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
@@ -9753,6 +10458,7 @@
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "dev": true,
       "license": "ISC",
@@ -9762,6 +10468,7 @@
     },
     "node_modules/zod-validation-error": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
       "dev": true,
       "license": "MIT",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,6 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/src/app/(modules)/l4-opcpa/components/color-legend.module.css
+++ b/frontend/src/app/(modules)/l4-opcpa/components/color-legend.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  font-size: 0.6875rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   letter-spacing: 0.04em;
 }

--- a/frontend/src/app/(modules)/l4-opcpa/components/l4-opcpa-view.tsx
+++ b/frontend/src/app/(modules)/l4-opcpa/components/l4-opcpa-view.tsx
@@ -32,9 +32,11 @@ export const L4OpcpaView: FC<L4OpcpaViewProps> = ({ specs }) => {
         )}
       </div>
       <LaserGrid>
-        {specs.map((spec) => (
-          <LaserPanelInstance key={spec.laser} spec={spec} />
-        ))}
+        {specs
+          .filter((spec) => spec.laser === 'NL2')
+          .map((spec) => (
+            <LaserPanelInstance key={spec.laser} spec={spec} />
+          ))}
       </LaserGrid>
     </div>
   )

--- a/frontend/src/app/(modules)/l4-opcpa/components/laser-grid.module.css
+++ b/frontend/src/app/(modules)/l4-opcpa/components/laser-grid.module.css
@@ -1,13 +1,16 @@
 .grid {
   display: flex;
   flex-direction: row;
-  gap: 0.75rem;
-  padding: 0.5rem 0;
+  flex-wrap: wrap; /* panels wrap to fit any width: 1/row on phones, many on TVs */
+  gap: 0.25rem;
+  padding: 0.25rem 0;
   align-items: start;
+  align-content: flex-start;
   color: var(--color-text);
 }
 
 .grid > * {
-  width: 280px;
-  flex-shrink: 0;
+  width: var(--hmi-panel-width);
+  max-width: 100%; /* never overflow a viewport narrower than a single panel */
+  flex: 0 0 auto;
 }

--- a/frontend/src/app/(modules)/l4-opcpa/components/laser-grid.tsx
+++ b/frontend/src/app/(modules)/l4-opcpa/components/laser-grid.tsx
@@ -2,8 +2,9 @@ import { FC, PropsWithChildren } from 'react'
 import styles from './laser-grid.module.css'
 
 /**
- * Flex row of fixed-width (280px) laser panels.
- * Horizontal overflow is caught by the global .page-container scroll container.
+ * Responsive grid of laser panels. Each panel is a fixed rem width
+ * (var(--hmi-panel-width)); the grid wraps, so the number of panels per row
+ * adapts to the viewport — 1 per row on a phone, several on a monitor or TV.
  */
 export const LaserGrid: FC<PropsWithChildren> = ({ children }) => {
   return <div className={styles.grid}>{children}</div>

--- a/frontend/src/app/(modules)/l4-opcpa/components/laser-panel-instance.test.tsx
+++ b/frontend/src/app/(modules)/l4-opcpa/components/laser-panel-instance.test.tsx
@@ -76,7 +76,7 @@ describe('LaserPanelInstance', () => {
     expect(screen.getByText('Chiller PS1225:11')).toBeInTheDocument()
     expect(screen.getByText('Flashlamps State')).toBeInTheDocument()
     expect(screen.getByText('Modbox State')).toBeInTheDocument()
-    expect(screen.getByText('Loaded Waveform')).toBeInTheDocument()
+    expect(screen.getByText('Waveform Preset')).toBeInTheDocument()
   })
 
   it('hides sections whose device bank is empty', () => {

--- a/frontend/src/app/(modules)/l4-opcpa/components/laser-panel-instance.tsx
+++ b/frontend/src/app/(modules)/l4-opcpa/components/laser-panel-instance.tsx
@@ -2,6 +2,8 @@
 
 import { FC } from 'react'
 import { LaserPanel } from '@/components/hmi/laser-panel'
+import { L4_OPCPA_SEQUENCES } from '@/components/hmi/laser-panel/SequencerSection'
+import { pv } from '../lib/pv-names'
 import type { LaserSpec } from '../config/schema'
 
 interface LaserPanelInstanceProps {
@@ -17,6 +19,15 @@ interface LaserPanelInstanceProps {
  */
 export const LaserPanelInstance: FC<LaserPanelInstanceProps> = ({ spec }) => (
   <LaserPanel title={spec.laser}>
+    {spec.pvs.sequencerRunning && (
+      <LaserPanel.Sequencer
+        sequencerRunningPv={spec.pvs.sequencerRunning}
+        sequences={L4_OPCPA_SEQUENCES.map((s) => ({
+          label: s.label,
+          statePv: pv.seqState(spec.laser, s.id),
+        }))}
+      />
+    )}
     <LaserPanel.General
       laser={spec.laser}
       connectionPv={spec.pvs.connection}
@@ -50,6 +61,9 @@ export const LaserPanelInstance: FC<LaserPanelInstanceProps> = ({ spec }) => (
         laser={spec.laser}
         modbox={spec.modbox}
         loadedWaveformPv={spec.pvs.loadedWaveform}
+        latestWaveformPv={spec.pvs.latestWaveform}
+        mbc1Pv={spec.pvs.modboxMbc1}
+        mbc2Pv={spec.pvs.modboxMbc2}
         commands={spec.commands}
       />
     )}

--- a/frontend/src/app/(modules)/l4-opcpa/config/README.md
+++ b/frontend/src/app/(modules)/l4-opcpa/config/README.md
@@ -37,7 +37,8 @@ line at the top wires up **autocomplete and inline error checking** from
 | `pvs.regenTemp` | PV name | Regen temperature readout. |
 | `pvs.phd2Mean` | PV name | Second PHD mean readout. |
 | `pvs.attenuator` | PV name | Attenuator value (read + direct write). |
-| `pvs.loadedWaveform` | PV name | Currently loaded waveform name. |
+| `pvs.loadedWaveform` | PV name | Current waveform preset. |
+| `pvs.latestWaveform` | PV name | Previous waveform moved into Waveform Latest when a new preset is applied. Optional. |
 | `triggerDelay` | PV name[] | Trigger-delay readouts; all should read equal (mismatch is flagged). |
 | `mss` | PV name[] | MSS sub-indicators counted in the Overview. |
 | `moduleErrors` | `{label, pv}`[] | Error indicators: `label` shown in UI, `pv` is the indicator PV. |

--- a/frontend/src/app/(modules)/l4-opcpa/config/lasers.schema.json
+++ b/frontend/src/app/(modules)/l4-opcpa/config/lasers.schema.json
@@ -59,7 +59,27 @@
               "loadedWaveform": {
                 "type": "string",
                 "minLength": 1,
-                "description": "Currently loaded waveform name."
+                "description": "Current waveform preset."
+              },
+              "latestWaveform": {
+                "description": "Previous waveform name shown in Waveform Latest after a new preset is applied.",
+                "type": "string",
+                "minLength": 1
+              },
+              "modboxMbc1": {
+                "description": "Modbox MBC1 readout (Modbox State row).",
+                "type": "string",
+                "minLength": 1
+              },
+              "modboxMbc2": {
+                "description": "Modbox MBC2 readout (Modbox State row).",
+                "type": "string",
+                "minLength": 1
+              },
+              "sequencerRunning": {
+                "description": "Sequencer running bool (Sequencer row: 1=RUNNING, 0=IDLE).",
+                "type": "string",
+                "minLength": 1
               }
             },
             "required": [

--- a/frontend/src/app/(modules)/l4-opcpa/config/lasers.yaml
+++ b/frontend/src/app/(modules)/l4-opcpa/config/lasers.yaml
@@ -69,6 +69,10 @@ lasers:
       phd2Mean: AI_NL2_PHD2_MEAN
       attenuator: AI_NL2_ATT
       loadedWaveform: SI_NL2_LOADED_WAVEFORM
+      latestWaveform: SI_NL2_LATEST_WAVEFORM
+      modboxMbc1: AI_NL2_MBC1
+      modboxMbc2: AI_NL2_MBC2
+      sequencerRunning: BI_NL2_SEQUENCER_RUNNING
     triggerDelay: [AI_NL2_TRIG_DELAY_CH1, AI_NL2_TRIG_DELAY_CH2]
     mss: [BI_NL2_MSS_1, BI_NL2_MSS_2, BI_NL2_MSS_3, BI_NL2_MSS_4, BI_NL2_MSS_5, BI_NL2_MSS_6]
     moduleErrors:

--- a/frontend/src/app/(modules)/l4-opcpa/config/schema.ts
+++ b/frontend/src/app/(modules)/l4-opcpa/config/schema.ts
@@ -52,7 +52,19 @@ export const rawLaserSchema = z.strictObject({
       regenTemp: pvName.describe('Regen temperature readout.'),
       phd2Mean: pvName.describe('Second PHD mean readout.'),
       attenuator: pvName.describe('Attenuator value (read + direct write).'),
-      loadedWaveform: pvName.describe('Currently loaded waveform name.'),
+      loadedWaveform: pvName.describe('Current waveform preset.'),
+      latestWaveform: pvName
+        .optional()
+        .describe('Previous waveform name shown in Waveform Latest after a new preset is applied.'),
+      modboxMbc1: pvName
+        .optional()
+        .describe('Modbox MBC1 readout (Modbox State row).'),
+      modboxMbc2: pvName
+        .optional()
+        .describe('Modbox MBC2 readout (Modbox State row).'),
+      sequencerRunning: pvName
+        .optional()
+        .describe('Sequencer running bool (Sequencer row: 1=RUNNING, 0=IDLE).'),
     })
     .describe('Single-signal read/write PVs.'),
   triggerDelay: z

--- a/frontend/src/app/(modules)/l4-opcpa/lib/pv-names.ts
+++ b/frontend/src/app/(modules)/l4-opcpa/lib/pv-names.ts
@@ -34,4 +34,14 @@ export const pv = {
    * surface at compile time instead of as a 400 from the backend.
    */
   cmd: (laser: string, name: LaserCommand) => `CMD_${laser}_${name}`,
+  /**
+   * Per-sequence state PV (`BI_<laser>_SEQ_<id>`, 1 = RUNNING, 0 = IDLE).
+   *
+   * PROOF-OF-CONCEPT: the real control system does not yet expose a state PV
+   * per sequence — this is mocked in the backend (l4_opcpa.go) so the expanded
+   * Sequencer can demonstrate per-sequence IDLE/RUNNING per the spec. The wire
+   * name reuses the command id so firing CMD_<laser>_<id> flips the matching
+   * SEQ state PV.
+   */
+  seqState: (laser: string, id: LaserCommand) => `BI_${laser}_SEQ_${id}`,
 } as const

--- a/frontend/src/app/(modules)/l4-opcpa/page.module.css
+++ b/frontend/src/app/(modules)/l4-opcpa/page.module.css
@@ -1,9 +1,9 @@
 .page {
-  --header-stack-height: 3rem;
+  --header-stack-height: 2rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  gap: 0.25rem;
+  padding: 0.375rem 0.5rem;
   width: 100%;
   box-sizing: border-box;
   color: var(--color-text);
@@ -17,7 +17,7 @@
   background: var(--color-background);
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.25rem;
 }
 
 .header {
@@ -25,22 +25,22 @@
   align-items: baseline;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  padding-bottom: 0.25rem;
+  gap: 0.375rem;
+  padding-bottom: 0.125rem;
   border-bottom: 1px solid var(--color-text-secondary);
 }
 
 .title {
   margin: 0;
-  font-size: 1rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
 
 .disconnected {
-  padding: 0.375rem 0.75rem;
-  font-size: 0.8125rem;
+  padding: 0.1875rem 0.375rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -25,6 +25,15 @@
   --color-text-secondary: var(--color-gray-600);
   --color-nav-background: var(--color-gray-800);
 
+  /* CSI-782 — L4 OPCPA panel design tokens (single source of truth for the
+   * panel width, spacing scale and typography; referenced by LaserPanel,
+   * laser-grid, SectionCard, DataRow and the section/control modules). */
+  --hmi-panel-width: 22rem; /* Density pass, then relaxed 21rem -> 22rem after a real truncation report: 21rem + a 7.25rem label left only ~8px label margin and truncated on machines where the font renders wider (browser min-font-size, or font-load fallback). 22rem restores robust margin on both the label column and the Modbox MBC cells while still fitting ~5 panels across (5*22rem = 1540px). */
+  --hmi-gap: 0.1429rem; /* between sections / inside the panel */
+  --hmi-gap-sm: 0.1429rem; /* between rows inside a card */
+  --hmi-font-size: 0.8125rem; /* one text size across the panel */
+  --hmi-row-min-h: 1.375rem; /* single row/control height across the panel (previously mixed 1.5rem for DataRow/Values vs 1.375rem for grid cells) */
+
   /* Status colors with light/dark variants */
   --color-primary-light: #3b91d2;
   --color-primary: #0284c7;
@@ -99,13 +108,22 @@ body {
   align-self: stretch;
 }
 
+/* Narrow screens (portrait phones / small tablets): stack the status sidebar
+   above the content so a panel gets the full viewport width instead of being
+   crushed beside a 168px sidebar. */
+@media (max-width: 640px) {
+  .layout-container {
+    flex-direction: column;
+  }
+}
+
 a {
   text-decoration: none;
 }
 
 html {
-  font-size: 14px;
-  font-family: 'Roboto Condensed', sans-serif;
+  font-size: clamp(12.5px, 0.5vw + 4.5px, 18px); /* fluid base unit so the fully rem-based UI adapts across phones -> monitors -> TVs. 12.5px floor (readable, and 5 panels fit in one row at 1600px), scaling to 18px on large/4K displays for across-room readability. Panels, gaps, sidebar and text all scale together, so nothing truncates. Browser zoom (Ctrl +/-) still works on top of this. */
+  font-family: 'Roboto Condensed', 'Arial Narrow', 'Roboto', system-ui, sans-serif; /* narrow fallbacks: if Roboto Condensed fails to load, degrade to a condensed-ish font instead of wide sans-serif (which overflows and truncates the fixed-width labels) */
   background: var(--color-background);
 }
 

--- a/frontend/src/components/hmi/controls/ActionButton.module.css
+++ b/frontend/src/components/hmi/controls/ActionButton.module.css
@@ -2,12 +2,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.375rem 0.5rem;
+  padding: 0.1875rem 0.375rem;
   font: inherit;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
   border-radius: 0;
   border: 1px solid var(--color-text);
   background: var(--color-surface-lighter);
@@ -29,54 +27,40 @@
   opacity: 0.7;
 }
 
-/* Primary actions: green border, slightly thicker. */
-.button[data-variant='primary'] {
-  border-color: var(--color-success-dark);
-  color: var(--color-success-dark);
-  border-width: 2px;
-  padding: calc(0.375rem - 1px) calc(0.5rem - 1px);
-}
-
-.button[data-variant='primary']:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--color-success) 14%, var(--color-surface-lighter));
-}
-
-.button[data-variant='secondary'] {
-  border-width: 1px;
-}
-
-/* Danger: red border + tint. */
+/* All variants share one uniform appearance (no green/red buttons). The
+ * `variant` prop is retained for semantics/aria but does not change colour. */
+.button[data-variant='primary'],
+.button[data-variant='secondary'],
 .button[data-variant='danger'] {
-  border-color: var(--color-error-dark);
-  color: var(--color-error-dark);
-  background: color-mix(in srgb, var(--color-error) 10%, var(--color-surface-lighter));
+  border-width: 1px;
+  border-color: var(--color-text);
+  color: var(--color-text);
+  background: var(--color-surface-lighter);
 }
 
+.button[data-variant='primary']:hover:not(:disabled),
+.button[data-variant='secondary']:hover:not(:disabled),
 .button[data-variant='danger']:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--color-error) 22%, var(--color-surface-lighter));
+  background: var(--color-surface);
 }
 
-/* Pending: dashed border. */
+/* Pending: dashed border only (no colour fill). */
 .button[data-state='pending'] {
   border-style: dashed;
   background: var(--color-surface-light);
 }
 
-/* Success: green fill flash. */
+/* Success / error: keep neutral chrome; the error message is surfaced in the
+ * separate errorRow below the button, so buttons never turn green/red. */
 .button[data-state='success'] {
-  background: color-mix(in srgb, var(--color-success) 28%, var(--color-surface-lighter));
-  color: var(--color-success-dark);
-  border-color: var(--color-success-dark);
+  background: var(--color-surface-light);
 }
 
-/* Error: red double border + red text. */
 .button[data-state='error'] {
-  background: color-mix(in srgb, var(--color-error) 18%, var(--color-surface-lighter));
-  color: var(--color-error-dark);
-  border-color: var(--color-error-dark);
   border-style: double;
-  border-width: 4px;
-  padding: calc(0.375rem - 3px) calc(0.5rem - 3px);
+  border-width: 3px;
+  padding: calc(0.1875rem - 2px) calc(0.375rem - 2px);
+  background: var(--color-surface-light);
 }
 
 .wrapper {
@@ -88,7 +72,7 @@
 
 .errorRow {
   margin-top: 0.125rem;
-  font-size: 0.6875rem;
+  font-size: var(--hmi-font-size);
   color: var(--color-error-dark);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/components/hmi/controls/CogToggle.module.css
+++ b/frontend/src/components/hmi/controls/CogToggle.module.css
@@ -4,22 +4,43 @@
   align-items: center;
 }
 
+/* Full-width action bars (General Actions / Modbox Actions) stack their panel
+ * in normal flow so it grows the card and stays inside the panel border,
+ * instead of an absolute dropdown that overflows the panel. */
+.wrapper[data-inline='true'] {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+}
+
 .button {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  justify-content: center;
+  gap: 0.1875rem;
   background: var(--color-surface-lighter);
   border: 1px solid var(--color-text);
   color: var(--color-text);
   font: inherit;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 0.125rem 0.375rem;
+  padding: 0.0625rem 0.25rem;
   border-radius: 0;
   cursor: pointer;
-  min-height: 1.5rem;
+  min-height: var(--hmi-row-min-h);
+  min-width: 0;
+}
+
+.button[data-has-inline-label='false'] {
+  width: var(--hmi-action-width, 1.75rem);
+  padding-inline: 0;
+}
+
+.button[data-has-inline-label='true'] {
+  width: 100%;
+  justify-content: flex-start;
+  padding-inline: 0.375rem;
 }
 
 .button:hover {
@@ -42,10 +63,21 @@
   z-index: 5;
   background: var(--color-surface-light);
   border: 1px solid var(--color-text);
-  padding: 0.5rem;
+  padding: 0.25rem;
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.1875rem;
   min-width: 14rem;
   box-shadow: var(--shadow-md);
+}
+
+/* Inline variant: in normal flow, full width, no shadow/dropdown offset, so
+ * the parent card grows to contain it and nothing escapes the panel border. */
+.panel[data-inline='true'] {
+  position: static;
+  right: auto;
+  margin-top: 0.125rem;
+  min-width: 0;
+  width: 100%;
+  box-shadow: none;
 }

--- a/frontend/src/components/hmi/controls/CogToggle.tsx
+++ b/frontend/src/components/hmi/controls/CogToggle.tsx
@@ -8,16 +8,20 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react'
+import { createPortal } from 'react-dom'
 import { SettingsIcon } from '@/components/ui/icons'
 import styles from './CogToggle.module.css'
 
 interface CogToggleProps {
   /** aria-label for the cog button. */
   ariaLabel: string
-  /** Optional inline label rendered next to the cog (e.g. "General Actions"). */
+  /** Optional inline label rendered next to the cog (e.g. "General Actions").
+   *  When present the panel expands in normal flow; when absent the panel is a
+   *  floating dropdown portaled to <body>. */
   inlineLabel?: ReactNode
 }
 
@@ -34,20 +38,32 @@ export const useCogToggleClose = (): (() => void) =>
   useContext(CogToggleContext)
 
 /**
- * Cog-icon button that toggles an inline panel of write actions. The panel
- * closes on Escape, on outside-click, and when a descendant write control
- * reports success via useCogToggleClose.
+ * Cog-icon button that toggles a panel of write actions. The panel closes on
+ * Escape, on outside-click, and when a descendant write control reports success
+ * via useCogToggleClose.
+ *
+ * Two render modes:
+ *  - inline (inlineLabel set): panel expands in normal flow inside the card.
+ *  - floating (no inlineLabel): panel is PORTALED to <body> and fixed-positioned
+ *    under the cog. Portaling is required so the dropdown is not clipped by the
+ *    scrollable page container (`.page-container { overflow: auto }`) or hidden
+ *    behind the sticky header — the same reason the tooltip portals.
  */
 export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
   ariaLabel,
   inlineLabel,
   children,
 }) => {
+  const isInline = Boolean(inlineLabel)
   const [open, setOpen] = useState(false)
+  const [pos, setPos] = useState<{ top: number; right: number } | null>(null)
   const wrapperRef = useRef<HTMLSpanElement | null>(null)
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const panelRef = useRef<HTMLDivElement | null>(null)
 
   const close = useCallback(() => setOpen(false), [])
 
+  // Escape closes.
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
@@ -57,39 +73,98 @@ export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
     return () => window.removeEventListener('keydown', onKey)
   }, [open, close])
 
+  // Outside-click closes. The floating panel is portaled OUTSIDE the wrapper, so
+  // clicks inside it must not count as "outside" — check both refs.
   useEffect(() => {
     if (!open) return
     const onDown = (e: MouseEvent) => {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(e.target as Node)
-      ) {
-        close()
-      }
+      const t = e.target as Node
+      if (wrapperRef.current?.contains(t)) return
+      if (panelRef.current?.contains(t)) return
+      close()
     }
     window.addEventListener('mousedown', onDown)
     return () => window.removeEventListener('mousedown', onDown)
   }, [open, close])
 
+  // Position the floating dropdown: fixed, below the button, right-aligned to it,
+  // flipped above if it would overflow the viewport bottom. Reposition on scroll
+  // (capture phase catches scrolling ancestors) and resize.
+  useLayoutEffect(() => {
+    if (!open || isInline) return
+    const place = () => {
+      const btn = buttonRef.current
+      if (!btn) return
+      const r = btn.getBoundingClientRect()
+      const gap = 4
+      const vw = window.innerWidth
+      const vh = window.innerHeight
+      const ph = panelRef.current?.offsetHeight ?? 0
+      let top = r.bottom + gap
+      if (ph && top + ph > vh - 8) top = Math.max(8, r.top - ph - gap)
+      const right = Math.max(8, vw - r.right)
+      setPos({ top, right })
+    }
+    place()
+    window.addEventListener('scroll', place, true)
+    window.addEventListener('resize', place)
+    return () => {
+      window.removeEventListener('scroll', place, true)
+      window.removeEventListener('resize', place)
+    }
+  }, [open, isInline])
+
+  const panelInner = (
+    <CogToggleContext.Provider value={close}>
+      <div
+        ref={panelRef}
+        className={styles.panel}
+        data-inline={isInline ? 'true' : 'false'}
+        data-floating={isInline ? undefined : 'true'}
+        style={
+          isInline
+            ? undefined
+            : {
+                position: 'fixed',
+                top: pos?.top ?? 0,
+                right: pos?.right ?? 0,
+                zIndex: 1000,
+                visibility: pos ? 'visible' : 'hidden',
+              }
+        }
+      >
+        {children}
+      </div>
+    </CogToggleContext.Provider>
+  )
+
   return (
-    <span className={styles.wrapper} ref={wrapperRef}>
+    <span
+      className={styles.wrapper}
+      ref={wrapperRef}
+      data-inline={isInline ? 'true' : 'false'}
+    >
       <button
+        ref={buttonRef}
         type="button"
         className={styles.button}
         aria-label={ariaLabel}
         aria-expanded={open}
+        data-has-inline-label={isInline ? 'true' : 'false'}
         onClick={() => setOpen((v) => !v)}
       >
         <SettingsIcon />
-        {inlineLabel ? (
+        {isInline ? (
           <span className={styles.inlineLabel}>{inlineLabel}</span>
         ) : null}
       </button>
-      {open ? (
-        <CogToggleContext.Provider value={close}>
-          <div className={styles.panel}>{children}</div>
-        </CogToggleContext.Provider>
-      ) : null}
+      {open
+        ? isInline
+          ? panelInner
+          : typeof document !== 'undefined'
+            ? createPortal(panelInner, document.body)
+            : null
+        : null}
     </span>
   )
 }

--- a/frontend/src/components/hmi/controls/DataRow.module.css
+++ b/frontend/src/components/hmi/controls/DataRow.module.css
@@ -1,17 +1,24 @@
 .row {
   display: grid;
-  grid-template-columns: minmax(0, 7rem) minmax(0, 1fr) auto;
+  grid-template-columns: var(--hmi-label-width, 13rem) minmax(0, 1fr);
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.8125rem;
-  line-height: 1.3;
+  gap: var(--hmi-column-gap, 0.375rem);
+  font-size: var(--hmi-font-size);
+  line-height: 1.15;
   color: var(--color-text);
-  min-height: 1.75rem;
+  min-height: var(--hmi-row-min-h);
+}
+
+.row[data-has-action='true'] {
+  grid-template-columns:
+    var(--hmi-label-width, 13rem)
+    minmax(0, 1fr)
+    var(--hmi-action-width, 1.75rem);
 }
 
 .label {
   color: var(--color-text);
-  font-weight: 400;
+  font-weight: 700;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -24,8 +31,8 @@
   min-width: 0;
   background: var(--color-surface-lighter);
   border: 1px solid var(--color-border);
-  padding: 0.125rem 0.5rem;
-  min-height: 1.5rem;
+  padding: 0.0625rem 0.25rem;
+  min-height: var(--hmi-row-min-h);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   overflow: hidden;
@@ -47,5 +54,15 @@
 .action {
   display: inline-flex;
   align-items: center;
-  flex-shrink: 0;
+  justify-content: stretch;
+  width: 100%;
+  min-width: 0;
+}
+
+.action > span {
+  width: 100%;
+}
+
+.action > span > button {
+  width: 100%;
 }

--- a/frontend/src/components/hmi/controls/DataRow.tsx
+++ b/frontend/src/components/hmi/controls/DataRow.tsx
@@ -29,7 +29,7 @@ export const DataRow: FC<DataRowProps> = ({
   const valueClass =
     valueVariant === 'bare' ? `${styles.value} ${styles.valueBare}` : styles.value
   return (
-    <div className={styles.row}>
+    <div className={styles.row} data-has-action={action ? 'true' : 'false'}>
       <span className={styles.label}>{label}</span>
       <span className={valueClass}>{value}</span>
       {action ? <span className={styles.action}>{action}</span> : null}

--- a/frontend/src/components/hmi/controls/DetailList.module.css
+++ b/frontend/src/components/hmi/controls/DetailList.module.css
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
   background: var(--color-surface-lighter);
   border: 1px solid var(--color-border);
   color: var(--color-text);
@@ -15,8 +15,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.5rem;
   padding: 0.125rem 0.5rem;
-  border-left: 3px solid transparent;
   min-width: 0;
 }
 
@@ -27,77 +27,69 @@
   min-width: 0;
 }
 
-.trailing {
+/* Single per-row indicator: text label (primary) + colour (secondary). */
+.status {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-width: 2.75rem;
+  padding: 0 0.375rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  flex-shrink: 0;
-  padding-left: 0.5rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  border: 1px solid var(--color-text);
+  background: var(--color-surface-lighter);
+  color: var(--color-text);
 }
 
-.dot {
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  background: var(--color-text-secondary);
-}
-
-.item[data-state='ok'] {
-  border-left-color: var(--color-success-dark);
-}
-.item[data-state='ok'] .dot {
-  background: var(--color-success-dark);
-}
-
-.item[data-state='err'] {
-  border-left-color: var(--color-error-dark);
-  font-weight: 700;
-}
-.item[data-state='err'] .dot {
-  background: var(--color-error-dark);
-}
-.item[data-state='err'] .trailing {
-  color: var(--color-error-dark);
-}
-
-.item[data-state='run'] {
-  border-left-color: var(--color-success-dark);
-}
-.item[data-state='run'] .trailing {
+.status[data-state='ok'] {
+  border-color: var(--color-success-dark);
   color: var(--color-success-dark);
 }
 
-.item[data-state='sb'] {
-  border-left-color: var(--color-gray-800);
+.status[data-state='err'] {
+  border-color: var(--color-error-dark);
+  color: var(--color-error-dark);
 }
-.item[data-state='sb'] .trailing {
+
+.status[data-state='run'] {
+  border-color: var(--color-success-dark);
+  color: var(--color-success-dark);
+}
+
+.status[data-state='sb'] {
+  border-color: var(--color-gray-800);
   color: var(--color-gray-800);
 }
 
-.item[data-state='stop'] {
-  border-left-color: var(--color-warning-dark);
-}
-.item[data-state='stop'] .trailing {
+.status[data-state='stop'] {
+  border-color: var(--color-warning-dark);
   color: var(--color-warning-dark);
 }
 
-.item[data-state='fail'] {
-  border-left-color: var(--color-error-dark);
-  font-weight: 700;
-}
-.item[data-state='fail'] .trailing {
+.status[data-state='fail'] {
+  border-color: var(--color-error-dark);
   color: var(--color-error-dark);
   text-decoration: underline double;
 }
 
-.item[data-state='unknown'] {
-  border-left-style: dotted;
-  border-left-color: var(--color-gray-800);
+.status[data-state='unknown'] {
+  border-style: dotted;
+  border-color: var(--color-gray-800);
   color: var(--color-gray-800);
 }
-.item[data-state='unknown'] .dot {
-  background: transparent;
-  border: 1px dotted currentColor;
+
+/* Explanatory note inside the expanded box (e.g. MSS). Black, regular,
+ * not italic, per the spec. */
+.note {
+  padding: 0.375rem 0.5rem 0.25rem;
+  font-size: var(--hmi-font-size);
+  font-weight: 400;
+  font-style: normal;
+  line-height: 1.35;
+  color: var(--color-text);
+  white-space: normal;
 }

--- a/frontend/src/components/hmi/controls/DetailList.tsx
+++ b/frontend/src/components/hmi/controls/DetailList.tsx
@@ -17,37 +17,53 @@ export type DetailListItemState =
 export interface DetailListItem {
   /** Display label (e.g. "MSS 1", "REGEN", "22 Ch1"). */
   label: string
-  /** Tone driving the per-item border + dot. */
+  /** Tone driving the single status indicator. */
   state: DetailListItemState
-  /** Optional text shown on the right (e.g. the literal state string). */
+  /** Optional explicit status text. When omitted, a default is derived from
+   * `state` so every row always shows a text label. */
   trailing?: string
 }
 
 interface DetailListProps {
   items: DetailListItem[]
+  /** Optional explanatory note rendered inside the box, below the items
+   * (e.g. the MSS "this is only a selection" note). Black, regular weight. */
+  note?: string
+}
+
+/** Default status text per state, so every indicator carries a text label
+ * (text primary, colour secondary). */
+const STATE_TEXT: Record<DetailListItemState, string> = {
+  ok: 'OK',
+  err: 'ERR',
+  run: 'RUN',
+  sb: 'SB',
+  stop: 'STOP',
+  fail: 'FAIL',
+  unknown: '<>',
 }
 
 /**
- * Expanded-detail list used by the four merged indicators in the wireframe:
- * MSS, Module Errors, Modbox State, and Flashlamps State. Each item has a
- * state tag that drives a left border + optional dot, so the operator can
- * spot the outliers at a glance.
+ * Expanded-detail list used by the merged indicators in the wireframe: MSS,
+ * Module Errors, Modbox State, and Flashlamps State.
+ *
+ * Each row shows exactly one status indicator: a text label (primary) tinted
+ * by colour (secondary). There is no separate left rectangle / right dot.
  */
-export const DetailList: FC<DetailListProps> = ({ items }) => {
+export const DetailList: FC<DetailListProps> = ({ items, note }) => {
   return (
     <ul className={styles.list}>
       {items.map((item) => (
-        <li
-          key={item.label}
-          className={styles.item}
-          data-state={item.state}
-        >
+        <li key={item.label} className={styles.item}>
           <span className={styles.label}>{item.label}</span>
-          <span className={styles.trailing}>
-            {item.trailing ?? <span className={styles.dot} aria-hidden />}
+          <span className={styles.status} data-state={item.state}>
+            {item.trailing ?? STATE_TEXT[item.state]}
           </span>
         </li>
       ))}
+      {note ? (
+        <li className={styles.note}>{note}</li>
+      ) : null}
     </ul>
   )
 }

--- a/frontend/src/components/hmi/controls/PresetIntegerInput.module.css
+++ b/frontend/src/components/hmi/controls/PresetIntegerInput.module.css
@@ -5,7 +5,7 @@
 }
 
 .label {
-  font-size: 0.6875rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   color: var(--color-text);
   text-transform: uppercase;
@@ -20,7 +20,7 @@
 
 .chip {
   font: inherit;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   padding: 0.25rem 0.375rem;
   border-radius: 0;
@@ -31,38 +31,38 @@
   font-variant-numeric: tabular-nums;
 }
 
-.chip:hover {
+.chip:hover:not(:disabled) {
   background: var(--color-surface);
 }
 
-/* Staged chip: green tint + green border. */
-.chip[data-staged='true'] {
-  border-color: var(--color-success-dark);
-  color: var(--color-success-dark);
-  background: color-mix(in srgb, var(--color-success) 22%, var(--color-surface-lighter));
+.chip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
+/* Custom value + inline Confirm sit on one row, Confirm next to the field. */
 .customRow {
   display: flex;
   align-items: center;
   gap: 0.375rem;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
   color: var(--color-text);
 }
 
 .customLabel {
   color: var(--color-text);
   text-transform: uppercase;
-  font-size: 0.6875rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   letter-spacing: 0.04em;
+  flex-shrink: 0;
 }
 
 .input {
   flex: 1;
   min-width: 0;
   font: inherit;
-  font-size: 0.8125rem;
+  font-size: var(--hmi-font-size);
   font-variant-numeric: tabular-nums;
   padding: 0.25rem 0.375rem;
   border-radius: 0;
@@ -71,16 +71,10 @@
   color: var(--color-text);
 }
 
-.actions {
-  display: grid;
-  grid-template-columns: 1fr 2fr;
-  gap: 0.25rem;
-}
-
-.cancel,
 .confirm {
+  flex-shrink: 0;
   font: inherit;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -92,44 +86,22 @@
   cursor: pointer;
 }
 
-.cancel:hover:not(:disabled),
 .confirm:hover:not(:disabled) {
   background: var(--color-surface);
 }
 
-.cancel:disabled,
 .confirm:disabled {
   opacity: 0.55;
   cursor: not-allowed;
 }
 
-/* Active confirm: green emphasis. */
-.confirm:not(:disabled) {
-  border-color: var(--color-success-dark);
-  color: var(--color-success-dark);
-  border-width: 2px;
-  padding: calc(0.25rem - 1px) calc(0.5rem - 1px);
-  background: color-mix(in srgb, var(--color-success) 14%, var(--color-surface-lighter));
-}
-
 .confirm[data-state='pending'] {
   border-style: dashed;
   background: var(--color-surface-light);
-  color: var(--color-text);
-  border-color: var(--color-text);
-}
-
-.confirm[data-state='error'] {
-  background: color-mix(in srgb, var(--color-error) 18%, var(--color-surface-lighter));
-  color: var(--color-error-dark);
-  border-color: var(--color-error-dark);
-  border-style: double;
-  border-width: 4px;
-  padding: calc(0.25rem - 3px) calc(0.5rem - 3px);
 }
 
 .errorRow {
-  font-size: 0.6875rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   color: var(--color-error-dark);
   text-transform: uppercase;

--- a/frontend/src/components/hmi/controls/PresetIntegerInput.test.tsx
+++ b/frontend/src/components/hmi/controls/PresetIntegerInput.test.tsx
@@ -34,25 +34,32 @@ describe('PresetIntegerInput', () => {
     expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled()
   })
 
-  it('stages a preset value on chip click and enables Confirm', async () => {
+  it('applies a preset immediately on chip click (no Confirm needed)', async () => {
+    const spy = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+    globalThis.fetch = spy as unknown as typeof fetch
     const user = userEvent.setup()
     renderInput()
     await user.click(screen.getByRole('button', { name: '790' }))
-    const confirm = screen.getByRole('button', { name: /Confirm/ })
-    expect(confirm).not.toBeDisabled()
-    expect(confirm).toHaveTextContent('790')
+    await waitFor(() => expect(spy).toHaveBeenCalled())
+    expect(spy.mock.calls[0][0]).toBe(
+      'http://localhost:8080/pv/CMD_NL2_SET_DELAY',
+    )
+    const init = spy.mock.calls[0][1] as RequestInit
+    expect(JSON.parse(init.body as string)).toEqual({ value: 790 })
   })
 
-  it('stages a custom value from the integer input field', async () => {
+  it('enables Confirm once a valid custom value is typed', async () => {
     const user = userEvent.setup()
     renderInput()
+    expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled()
     await user.type(screen.getByLabelText(/custom/i), '650')
-    const confirm = screen.getByRole('button', { name: /Confirm/ })
-    expect(confirm).not.toBeDisabled()
-    expect(confirm).toHaveTextContent('650')
+    expect(screen.getByRole('button', { name: /Confirm/ })).not.toBeDisabled()
   })
 
-  it('POSTs to /pv/<pvName> with the staged value when Confirm is clicked', async () => {
+  it('POSTs to /pv/<pvName> with the custom value when Confirm is clicked', async () => {
     const spy = vi.fn<typeof fetch>(
       async () =>
         new Response(JSON.stringify({ ok: true }), { status: 200 }),
@@ -61,7 +68,7 @@ describe('PresetIntegerInput', () => {
     const user = userEvent.setup()
     renderInput()
 
-    await user.click(screen.getByRole('button', { name: '500' }))
+    await user.type(screen.getByLabelText(/custom/i), '500')
     await user.click(screen.getByRole('button', { name: /Confirm/ }))
 
     await waitFor(() => expect(spy).toHaveBeenCalled())
@@ -72,11 +79,13 @@ describe('PresetIntegerInput', () => {
     expect(JSON.parse(init.body as string)).toEqual({ value: 500 })
   })
 
-  it('Cancel clears the staged value and disables Confirm again', async () => {
+  it('disables Confirm again when the custom field is cleared', async () => {
     const user = userEvent.setup()
     renderInput()
-    await user.click(screen.getByRole('button', { name: '790' }))
-    await user.click(screen.getByRole('button', { name: /Cancel/ }))
+    const input = screen.getByLabelText(/custom/i)
+    await user.type(input, '790')
+    expect(screen.getByRole('button', { name: /Confirm/ })).not.toBeDisabled()
+    await user.clear(input)
     expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled()
   })
 

--- a/frontend/src/components/hmi/controls/PresetIntegerInput.tsx
+++ b/frontend/src/components/hmi/controls/PresetIntegerInput.tsx
@@ -7,7 +7,7 @@ import styles from './PresetIntegerInput.module.css'
 interface PresetIntegerInputProps {
   label: string
   presets: readonly number[]
-  /** PV to write the staged integer value to (e.g. `CMD_NL2_SET_DELAY` or
+  /** PV to write the integer value to (e.g. `CMD_NL2_SET_DELAY` or
    * `AI_NL2_ATT`). */
   pvName: string
   /** Optional inclusive minimum. Values below this disable Confirm. */
@@ -16,6 +16,15 @@ interface PresetIntegerInputProps {
   max?: number
 }
 
+/**
+ * Integer setter used by Trigger Delay and the Attenuator.
+ *
+ * - Preset buttons apply immediately on click (one click = one write); they do
+ *   NOT require a separate confirm.
+ * - A custom value is typed into the field and committed with the inline
+ *   Confirm button sitting directly next to the field.
+ * - There is no Cancel button.
+ */
 export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
   label,
   presets,
@@ -38,7 +47,7 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
       ? `Out of range (${min ?? '−∞'}..${max ?? '∞'})`
       : null
 
-  // Reset the staged value after a successful write. `state` is the external
+  // Clear the custom field after a successful write. `state` is the external
   // signal from usePvWrite; adjust local state during render off its transition
   // (React's "storing information from previous renders" pattern) instead of in
   // an effect, so the reset lands in the same commit.
@@ -81,17 +90,14 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
     setStaged(n)
   }, [])
 
-  const onChipClick = useCallback((value: number) => {
-    setStaged(value)
-    setCustomText('')
-    setParseError(null)
-  }, [])
-
-  const onCancel = useCallback(() => {
-    setStaged(null)
-    setCustomText('')
-    setParseError(null)
-  }, [])
+  // Preset chips apply immediately — one click writes the value.
+  const onChipClick = useCallback(
+    (value: number) => {
+      if (pending) return
+      void write(pvName, value)
+    },
+    [pending, write, pvName],
+  )
 
   const onConfirm = useCallback(() => {
     if (staged === null) return
@@ -112,7 +118,7 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
               key={p}
               type="button"
               className={styles.chip}
-              data-staged={staged === p}
+              disabled={pending}
               onClick={() => onChipClick(p)}
             >
               {p}
@@ -120,8 +126,10 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
           ))}
         </div>
       )}
-      <label className={styles.customRow} htmlFor={inputId}>
-        <span className={styles.customLabel}>Custom</span>
+      <div className={styles.customRow}>
+        <label className={styles.customLabel} htmlFor={inputId}>
+          Custom
+        </label>
         <input
           id={inputId}
           className={styles.input}
@@ -132,16 +140,6 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
           max={max}
           onChange={(e) => onCustomChange(e.target.value)}
         />
-      </label>
-      <div className={styles.actions}>
-        <button
-          type="button"
-          className={styles.cancel}
-          onClick={onCancel}
-          disabled={staged === null && customText === ''}
-        >
-          Cancel
-        </button>
         <button
           type="button"
           className={styles.confirm}
@@ -149,11 +147,7 @@ export const PresetIntegerInput: FC<PresetIntegerInputProps> = ({
           disabled={!stagedValid || pending}
           data-state={pending ? 'pending' : error ? 'error' : 'idle'}
         >
-          {staged !== null
-            ? pending
-              ? `Setting ${staged}…`
-              : `Confirm ${staged}`
-            : 'Confirm'}
+          {pending ? 'Setting…' : 'Confirm'}
         </button>
       </div>
       {(error || rangeError || parseError) && (

--- a/frontend/src/components/hmi/controls/SectionCard.module.css
+++ b/frontend/src/components/hmi/controls/SectionCard.module.css
@@ -1,26 +1,29 @@
 .card {
+  --hmi-label-width: 8.5rem; /* was 9.25rem, briefly 7.25rem (too tight — truncated in the field). Widest device label ("Regen SY3PL50M:32") measures 94px with the font loaded; 8.5rem (119px) keeps ~25px margin and still holds a narrow fallback font. */
+  --hmi-action-width: 2.25rem;
+  --hmi-column-gap: 0.1429rem;
   background: var(--color-surface-light);
   border: 1px solid var(--color-text);
-  padding: 0.5rem 0.625rem;
+  padding: 0.1875rem 0.375rem;
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: var(--hmi-gap-sm);
   color: var(--color-text);
 }
 
 .title {
   margin: 0;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--color-text);
   border-bottom: 1px solid var(--color-text);
-  padding-bottom: 0.25rem;
+  padding-bottom: 0.125rem;
 }
 
 .body {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: var(--hmi-gap-sm);
 }

--- a/frontend/src/components/hmi/controls/Values.module.css
+++ b/frontend/src/components/hmi/controls/Values.module.css
@@ -1,4 +1,6 @@
 .number {
+  display: block;
+  margin-left: auto;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   color: var(--color-text);
@@ -6,7 +8,7 @@
 
 .units {
   margin-left: 0.375rem;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
   font-weight: 400;
   color: var(--color-gray-800);
 }
@@ -18,7 +20,7 @@
 
 .placeholder {
   font-family: 'Roboto Condensed', monospace;
-  font-size: 0.875rem;
+  font-size: var(--hmi-font-size);
   font-weight: 400;
   color: var(--color-gray-800);
 }
@@ -28,15 +30,13 @@
   align-items: center;
   justify-content: center;
   padding: 0.125rem 0.5rem;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
   border: 1px solid var(--color-text);
   background: var(--color-surface-lighter);
   color: var(--color-text);
   width: 100%;
-  min-height: 1.5rem;
+  min-height: var(--hmi-row-min-h);
   font-variant-numeric: tabular-nums;
 }
 

--- a/frontend/src/components/hmi/controls/Values.tsx
+++ b/frontend/src/components/hmi/controls/Values.tsx
@@ -24,28 +24,18 @@ export const FloatValue: FC<{ data: NumMsg; precision?: number }> = ({
   data,
   precision = 3,
 }) => {
-  if (!data || !data.ok || typeof data.value !== 'number') {
+  if (!data || !data.ok || !Number.isFinite(data.value)) {
     return <span className={styles.placeholder}>{EMPTY}</span>
   }
-  return (
-    <>
-      <span className={styles.number}>{data.value.toFixed(precision)}</span>
-      {data.units && <span className={styles.units}>{data.units}</span>}
-    </>
-  )
+  return <span className={styles.number}>{data.value!.toFixed(precision)}</span>
 }
 
 /** Integer value. */
 export const IntegerValue: FC<{ data: NumMsg }> = ({ data }) => {
-  if (!data || !data.ok || typeof data.value !== 'number') {
+  if (!data || !data.ok || !Number.isFinite(data.value)) {
     return <span className={styles.placeholder}>{EMPTY}</span>
   }
-  return (
-    <>
-      <span className={styles.number}>{Math.round(data.value)}</span>
-      {data.units && <span className={styles.units}>{data.units}</span>}
-    </>
-  )
+  return <span className={styles.number}>{Math.round(data.value!)}</span>
 }
 
 /** String value. */

--- a/frontend/src/components/hmi/laser-panel/ChillerCell.tsx
+++ b/frontend/src/components/hmi/laser-panel/ChillerCell.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { FC } from 'react'
+import type { Message } from '@/app/providers/types'
+import {
+  deriveCellState,
+  type Limits,
+} from './chiller-cell-state'
+import styles from './sections.module.css'
+
+interface ChillerCellProps {
+  msg: Message<number | null> | undefined
+  isConnected: boolean
+  limits?: Limits
+  deviceOff?: boolean
+  precision?: number
+}
+
+/**
+ * One Flow/Temp/Water cell. Delegates all decision-making to
+ * {@link deriveCellState} (CSI-783) and renders text + tone + tooltip. The
+ * `data-tone` attribute drives the colour (see sections.module.css
+ * `.cellState[data-tone=...]`).
+ */
+export const ChillerCell: FC<ChillerCellProps> = ({
+  msg,
+  isConnected,
+  limits,
+  deviceOff,
+  precision = 3,
+}) => {
+  const view = deriveCellState({ msg, isConnected, limits, deviceOff, precision })
+  return (
+    <span
+      className={styles.cellState}
+      data-tone={view.tone}
+      data-kind={view.kind}
+      title={view.title}
+    >
+      {view.text}
+    </span>
+  )
+}

--- a/frontend/src/components/hmi/laser-panel/ChillersSection.tsx
+++ b/frontend/src/components/hmi/laser-panel/ChillersSection.tsx
@@ -2,9 +2,10 @@
 
 import { FC, useMemo } from 'react'
 import { SectionCard } from '@/components/hmi/controls/SectionCard'
-import { FloatValue } from '@/components/hmi/controls/Values'
 import { useWebSocketData } from '@/lib/websocket/use-websocket-data'
 import type { ChillerSpec } from '@/app/(modules)/l4-opcpa/config/schema'
+import { ChillerCell } from './ChillerCell'
+import { CHILLER_LIMITS } from './chiller-cell-state'
 import styles from './sections.module.css'
 
 interface ChillersSectionProps {
@@ -15,14 +16,17 @@ interface ChillersSectionProps {
 /**
  * Chiller flow/temp/water-level grid. One row per chiller, three columns
  * (Flow / Temp / Water) plus a header row. PV names arrive verbatim from the
- * YAML config.
+ * YAML config. Each cell resolves an explicit state (CSI-783) via ChillerCell.
  */
 export const ChillersSection: FC<ChillersSectionProps> = ({ chillers }) => {
   const pvs = useMemo(
     () => chillers.flatMap((c) => [c.flow, c.temp, c.level]),
     [chillers],
   )
-  const { state } = useWebSocketData<number | null>({ pvs, raw: true })
+  const { state, isConnected } = useWebSocketData<number | null>({
+    pvs,
+    raw: true,
+  })
 
   return (
     <SectionCard>
@@ -36,13 +40,25 @@ export const ChillersSection: FC<ChillersSectionProps> = ({ chillers }) => {
           <div key={c.flow} className={styles.contents}>
             <span className={styles.rowLabel}>Chiller {c.label}</span>
             <span className={styles.numCell}>
-              <FloatValue data={state[c.flow]} precision={3} />
+              <ChillerCell
+                msg={state[c.flow]}
+                isConnected={isConnected}
+                limits={CHILLER_LIMITS.flow}
+              />
             </span>
             <span className={styles.numCell}>
-              <FloatValue data={state[c.temp]} precision={3} />
+              <ChillerCell
+                msg={state[c.temp]}
+                isConnected={isConnected}
+                limits={CHILLER_LIMITS.temp}
+              />
             </span>
             <span className={styles.numCell}>
-              <FloatValue data={state[c.level]} precision={3} />
+              <ChillerCell
+                msg={state[c.level]}
+                isConnected={isConnected}
+                limits={CHILLER_LIMITS.level}
+              />
             </span>
           </div>
         ))}

--- a/frontend/src/components/hmi/laser-panel/FlashlampsSection.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/FlashlampsSection.test.tsx
@@ -76,7 +76,7 @@ describe('FlashlampsSection', () => {
 
     const user = userEvent.setup()
     expect(
-      screen.queryByRole('button', { name: 'Set All Run' }),
+      screen.queryByRole('button', { name: 'Set All to Run' }),
     ).not.toBeInTheDocument()
 
     await user.click(
@@ -84,10 +84,10 @@ describe('FlashlampsSection', () => {
     )
 
     expect(
-      screen.getByRole('button', { name: 'Set All Run' }),
+      screen.getByRole('button', { name: 'Set All to Run' }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Set All Standby' }),
+      screen.getByRole('button', { name: 'Set All to Standby' }),
     ).toBeInTheDocument()
   })
 

--- a/frontend/src/components/hmi/laser-panel/FlashlampsSection.tsx
+++ b/frontend/src/components/hmi/laser-panel/FlashlampsSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, useMemo, useState } from 'react'
+import { FC, useMemo, useRef, useState } from 'react'
 import { SectionCard } from '@/components/hmi/controls/SectionCard'
 import { DataRow } from '@/components/hmi/controls/DataRow'
 import { CogToggle } from '@/components/hmi/controls/CogToggle'
@@ -10,11 +10,11 @@ import {
   DetailList,
   DetailListItem,
 } from '@/components/hmi/controls/DetailList'
-import { ChevronIcon } from '@/components/ui/icons'
 import { useWebSocketData } from '@/lib/websocket/use-websocket-data'
 import { pv, type LaserCommand } from '@/app/(modules)/l4-opcpa/lib/pv-names'
 import type { LabeledPv } from '@/app/(modules)/l4-opcpa/config/schema'
 import { makeCommandGate } from './commandGate'
+import { useCollapseOnAnyClick } from './use-collapse-on-any-click'
 import styles from './sections.module.css'
 
 interface FlashlampsSectionProps {
@@ -64,6 +64,8 @@ export const FlashlampsSection: FC<FlashlampsSectionProps> = ({
   commands,
 }) => {
   const [expanded, setExpanded] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  useCollapseOnAnyClick(expanded, () => setExpanded(false), triggerRef)
   const can = makeCommandGate(commands)
   const hasFlashlampActions = can('FLASHLAMPS_RUN') || can('FLASHLAMPS_STANDBY')
 
@@ -137,6 +139,7 @@ export const FlashlampsSection: FC<FlashlampsSectionProps> = ({
         <span />
 
         <button
+          ref={triggerRef}
           type="button"
           className={styles.flashlampStateButton}
           aria-expanded={expanded}
@@ -144,9 +147,11 @@ export const FlashlampsSection: FC<FlashlampsSectionProps> = ({
           onClick={() => setExpanded((v) => !v)}
         >
           <span>Flashlamps State</span>
-          <span className={styles.flashlampStateChevron}>
-            <ChevronIcon expanded={expanded} />
-          </span>
+          <span
+            className={styles.cornerTriangle}
+            data-expanded={expanded || undefined}
+            aria-hidden
+          />
         </button>
         {STATES.map((s) => (
           <span
@@ -162,13 +167,13 @@ export const FlashlampsSection: FC<FlashlampsSectionProps> = ({
           <CogToggle ariaLabel="Flashlamps actions">
             {can('FLASHLAMPS_RUN') && (
               <ActionButton
-                label="Set All Run"
+                label="Set All to Run"
                 pvName={pv.cmd(laser, 'FLASHLAMPS_RUN')}
               />
             )}
             {can('FLASHLAMPS_STANDBY') && (
               <ActionButton
-                label="Set All Standby"
+                label="Set All to Standby"
                 pvName={pv.cmd(laser, 'FLASHLAMPS_STANDBY')}
                 variant="secondary"
               />

--- a/frontend/src/components/hmi/laser-panel/GeneralSection.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/GeneralSection.test.tsx
@@ -77,11 +77,25 @@ describe('GeneralSection', () => {
     expect(screen.getByText('FULLP')).toBeInTheDocument()
     expect(screen.getByText('MSS')).toBeInTheDocument()
     expect(screen.getByText('ERR')).toBeInTheDocument()
-    expect(screen.getByText('YES')).toBeInTheDocument()
+    // CONN=1 and MSS(all ok)=YES → two YES pills.
+    expect(screen.getAllByText('YES')).toHaveLength(2)
     expect(screen.getByText('NO')).toBeInTheDocument()
-    expect(screen.getByText('3 / 3')).toBeInTheDocument()
-    // 1 module is in error out of 2 total.
-    expect(screen.getByText('1 / 2')).toBeInTheDocument()
+    // MSS overall must be YES/NO, never a numeric count (spec).
+    expect(screen.queryByText('3/3')).not.toBeInTheDocument()
+    // ERR remains a numeric count: 1 module in error out of 2 total.
+    expect(screen.getByText('1/2')).toBeInTheDocument()
+  })
+
+  it('shows MSS overall as NO (not a count) when any indicator is not ok', async () => {
+    const ws = await setup()
+    act(() => {
+      ws.push('BI_NL2_MSS_1', 1)
+      ws.push('BI_NL2_MSS_2', 0)
+      ws.push('BI_NL2_MSS_3', 1)
+    })
+    // Only MSS has data here → exactly one NO pill, and no "2/3" count.
+    expect(screen.getByText('NO')).toBeInTheDocument()
+    expect(screen.queryByText('2/3')).not.toBeInTheDocument()
   })
 
   it('renders the Shutter row with an inline status pill', async () => {
@@ -116,10 +130,10 @@ describe('GeneralSection', () => {
       screen.getByRole('button', { name: 'Stop Laser' }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Alignment Mode' }),
+      screen.getByRole('button', { name: 'Set to Alignment Mode' }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'System Standby' }),
+      screen.getByRole('button', { name: 'Set to System Standby' }),
     ).toBeInTheDocument()
   })
 
@@ -185,14 +199,14 @@ describe('GeneralSection', () => {
       screen.getByRole('button', { name: 'Start Laser' }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Alignment Mode' }),
+      screen.getByRole('button', { name: 'Set to Alignment Mode' }),
     ).toBeInTheDocument()
     // Not listed → hidden.
     expect(
       screen.queryByRole('button', { name: 'Stop Laser' }),
     ).not.toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: 'System Standby' }),
+      screen.queryByRole('button', { name: 'Set to System Standby' }),
     ).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/hmi/laser-panel/GeneralSection.tsx
+++ b/frontend/src/components/hmi/laser-panel/GeneralSection.tsx
@@ -118,14 +118,14 @@ export const GeneralSection: FC<GeneralSectionProps> = ({
             )}
             {can('ALIGNMENT_MODE') && (
               <ActionButton
-                label="Alignment Mode"
+                label="Set to Alignment Mode"
                 pvName={pv.cmd(laser, 'ALIGNMENT_MODE')}
                 variant="secondary"
               />
             )}
             {can('SYSTEM_STANDBY') && (
               <ActionButton
-                label="System Standby"
+                label="Set to System Standby"
                 pvName={pv.cmd(laser, 'SYSTEM_STANDBY')}
                 variant="secondary"
               />

--- a/frontend/src/components/hmi/laser-panel/LaserPanel.module.css
+++ b/frontend/src/components/hmi/laser-panel/LaserPanel.module.css
@@ -1,11 +1,11 @@
 .panel {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--hmi-gap);
   background: var(--color-surface);
   border: 1px solid var(--color-text-secondary);
   padding: 0;
-  min-width: 280px;
+  min-width: var(--hmi-panel-width);
   color: var(--color-text);
 }
 
@@ -15,13 +15,13 @@
   z-index: 1;
   background: var(--color-text);
   color: var(--color-surface-lighter);
-  padding: 0.375rem 0.625rem;
+  padding: 0.1875rem 0.375rem;
   border-bottom: 1px solid var(--color-text);
 }
 
 .title {
   margin: 0;
-  font-size: 1rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -31,6 +31,6 @@
 .body {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 0 0 0.5rem;
+  gap: var(--hmi-gap);
+  padding: 0 0 0.1429rem;
 }

--- a/frontend/src/components/hmi/laser-panel/LaserPanel.tsx
+++ b/frontend/src/components/hmi/laser-panel/LaserPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { FC, PropsWithChildren } from 'react'
+import { SequencerSection } from './SequencerSection'
 import { GeneralSection } from './GeneralSection'
 import { RegenSection } from './RegenSection'
 import { ChillersSection } from './ChillersSection'
@@ -21,6 +22,7 @@ interface LaserPanelProps {
  * code. `laser` is passed only where command PVs are needed.
  */
 export const LaserPanel: FC<PropsWithChildren<LaserPanelProps>> & {
+  Sequencer: typeof SequencerSection
   General: typeof GeneralSection
   Regen: typeof RegenSection
   Chillers: typeof ChillersSection
@@ -37,6 +39,7 @@ export const LaserPanel: FC<PropsWithChildren<LaserPanelProps>> & {
   )
 }
 
+LaserPanel.Sequencer = SequencerSection
 LaserPanel.General = GeneralSection
 LaserPanel.Regen = RegenSection
 LaserPanel.Chillers = ChillersSection

--- a/frontend/src/components/hmi/laser-panel/ModboxSection.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/ModboxSection.test.tsx
@@ -43,7 +43,7 @@ function renderModbox() {
 }
 
 describe('ModboxSection', () => {
-  it('renders the merged Modbox state pill and Loaded Waveform readout', async () => {
+  it('renders the merged Modbox state pill and Waveform Preset readout', async () => {
     const ws = renderModbox()
 
     await waitFor(() =>
@@ -61,8 +61,8 @@ describe('ModboxSection', () => {
     })
 
     expect(screen.getByText('Modbox State')).toBeInTheDocument()
-    expect(screen.getByText('2 / 3')).toBeInTheDocument()
-    expect(screen.getByText('Loaded Waveform')).toBeInTheDocument()
+    expect(screen.getByText('2/3')).toBeInTheDocument()
+    expect(screen.getByText('Waveform Preset')).toBeInTheDocument()
     expect(screen.getAllByText('std-100ps').length).toBeGreaterThan(0)
   })
 
@@ -122,9 +122,97 @@ describe('ModboxSection', () => {
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
 
     await user.click(
-      screen.getByRole('button', { name: 'Set waveform' }),
+      screen.getByRole('button', { name: 'Set waveform preset' }),
     )
 
     expect(screen.getByRole('combobox')).toBeInTheDocument()
+  })
+
+  it('exposes "Set Waveform to…" inside the Modbox Actions group and reveals the selectbox + CONFIRM', async () => {
+    const ws = renderModbox()
+    await waitFor(() =>
+      expect(ws.subscriptions.get('BI_NL2_MODBOX_1')?.size).toBe(1),
+    )
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Modbox actions' }))
+
+    const waveformAction = screen.getByRole('button', {
+      name: 'Set Waveform to…',
+    })
+    expect(waveformAction).toBeInTheDocument()
+    // Collapsed until pressed.
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+
+    await user.click(waveformAction)
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'CONFIRM' }),
+    ).toBeInTheDocument()
+  })
+
+  it('collapses "Set Waveform to…" when Modbox Actions is closed and reopened', async () => {
+    const ws = renderModbox()
+    await waitFor(() =>
+      expect(ws.subscriptions.get('BI_NL2_MODBOX_1')?.size).toBe(1),
+    )
+
+    const user = userEvent.setup()
+    const actionsToggle = screen.getByRole('button', {
+      name: 'Modbox actions',
+    })
+
+    await user.click(actionsToggle)
+    await user.click(
+      screen.getByRole('button', { name: 'Set Waveform to…' }),
+    )
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+
+    await user.click(actionsToggle)
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+
+    await user.click(actionsToggle)
+    expect(
+      screen.getByRole('button', { name: 'Set Waveform to…' }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+
+  it('renders MBC1 / MBC2 readouts and the Waveform Latest row when configured', async () => {
+    const ws = makeFakeWebSocketContext()
+    render(
+      <TestWebSocketProvider value={ws.context}>
+        <ModboxSection
+          laser="NL2"
+          modbox={MODBOX_3}
+          loadedWaveformPv="SI_NL2_LOADED_WAVEFORM"
+          latestWaveformPv="SI_NL2_LATEST_WAVEFORM"
+          mbc1Pv="AI_NL2_MBC1"
+          mbc2Pv="AI_NL2_MBC2"
+          commands={LASER_COMMANDS}
+        />
+      </TestWebSocketProvider>,
+    )
+
+    await waitFor(() =>
+      expect(ws.subscriptions.get('AI_NL2_MBC1')?.size).toBe(1),
+    )
+    await waitFor(() =>
+      expect(ws.subscriptions.get('SI_NL2_LATEST_WAVEFORM')?.size).toBe(1),
+    )
+
+    act(() => {
+      ws.push('AI_NL2_MBC1', 12.34)
+      ws.push('AI_NL2_MBC2', 56.78)
+      ws.push('SI_NL2_LATEST_WAVEFORM', 'narrow-50ps')
+    })
+
+    expect(screen.getByText('MBC1')).toBeInTheDocument()
+    expect(screen.getByText('MBC2')).toBeInTheDocument()
+    expect(screen.getByText('12.34')).toBeInTheDocument()
+    expect(screen.getByText('56.78')).toBeInTheDocument()
+    expect(screen.getByText('Waveform Latest')).toBeInTheDocument()
+    expect(screen.getAllByText('narrow-50ps').length).toBeGreaterThan(0)
   })
 })

--- a/frontend/src/components/hmi/laser-panel/ModboxSection.tsx
+++ b/frontend/src/components/hmi/laser-panel/ModboxSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, useMemo, useState } from 'react'
+import { FC, useMemo, useRef, useState } from 'react'
 import { SectionCard } from '@/components/hmi/controls/SectionCard'
 import { DataRow } from '@/components/hmi/controls/DataRow'
 import { CogToggle } from '@/components/hmi/controls/CogToggle'
@@ -9,13 +9,13 @@ import {
   DetailList,
   DetailListItem,
 } from '@/components/hmi/controls/DetailList'
-import { StringValue } from '@/components/hmi/controls/Values'
+import { FloatValue, StringValue } from '@/components/hmi/controls/Values'
 import type { Message } from '@/app/providers/types'
-import { ChevronIcon } from '@/components/ui/icons'
 import { useWebSocketData } from '@/lib/websocket/use-websocket-data'
 import { pv, type LaserCommand } from '@/app/(modules)/l4-opcpa/lib/pv-names'
 import { WaveformSelect } from './WaveformSelect'
 import { makeCommandGate } from './commandGate'
+import { useCollapseOnAnyClick } from './use-collapse-on-any-click'
 import styles from './sections.module.css'
 
 interface ModboxSectionProps {
@@ -23,10 +23,33 @@ interface ModboxSectionProps {
   laser: string
   /** Modbox state PVs (1 = OK). */
   modbox: readonly string[]
-  /** Currently-loaded-waveform PV. */
+  /** Currently-loaded-waveform PV (Waveform Preset). */
   loadedWaveformPv: string
+  /** Previous-waveform PV shown in Waveform Latest. Optional. */
+  latestWaveformPv?: string
+  /** Modbox MBC1 / MBC2 readout PVs (shown on the Modbox State row). Optional. */
+  mbc1Pv?: string
+  mbc2Pv?: string
   /** Commands this laser exposes. Buttons for commands not listed are hidden. */
   commands: readonly LaserCommand[]
+}
+
+const WaveformActionDisclosure: FC<{ laser: string }> = ({ laser }) => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className={styles.waveformAction}>
+      <button
+        type="button"
+        className={styles.waveformActionToggle}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        Set Waveform to…
+      </button>
+      {open && <WaveformSelect laser={laser} />}
+    </div>
+  )
 }
 
 /**
@@ -37,15 +60,29 @@ export const ModboxSection: FC<ModboxSectionProps> = ({
   laser,
   modbox,
   loadedWaveformPv,
+  latestWaveformPv,
+  mbc1Pv,
+  mbc2Pv,
   commands,
 }) => {
   const [expanded, setExpanded] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  useCollapseOnAnyClick(expanded, () => setExpanded(false), triggerRef)
   const can = makeCommandGate(commands)
-  const hasModboxActions = can('MODBOX_ON') || can('MODBOX_OFF')
+  const hasWaveformAction = can('LOAD_WAVEFORM')
+  const hasModboxActions =
+    can('MODBOX_ON') || can('MODBOX_OFF') || hasWaveformAction
 
   const allPvs = useMemo(
-    () => [...modbox, loadedWaveformPv],
-    [modbox, loadedWaveformPv],
+    () =>
+      [
+        ...modbox,
+        loadedWaveformPv,
+        latestWaveformPv,
+        mbc1Pv,
+        mbc2Pv,
+      ].filter((p): p is string => Boolean(p)),
+    [modbox, loadedWaveformPv, latestWaveformPv, mbc1Pv, mbc2Pv],
   )
   // Mixed value types (number for state, string for waveform). Keep the hook
   // typed as `unknown` and narrow at the use site.
@@ -78,46 +115,62 @@ export const ModboxSection: FC<ModboxSectionProps> = ({
         label="Modbox State"
         valueVariant="bare"
         value={
-          <button
-            type="button"
-            className={styles.modboxStateButton}
-            aria-expanded={expanded}
-            aria-label="Toggle Modbox state detail"
-            onClick={() => setExpanded((v) => !v)}
+          <div
+            className={styles.modboxRow}
+            data-layout={mbc1Pv || mbc2Pv ? 'with-mbc' : 'bool-only'}
           >
-            <span className={styles.modboxStatePill} data-tone={tone}>
-              <span className={styles.modboxStateCount}>
-                {okCount} / {total}
-              </span>
-              <span className={styles.modboxStateChevron}>
-                <ChevronIcon expanded={expanded} />
-              </span>
+            <span className={styles.mbcCol}>
+              {(mbc1Pv || mbc2Pv) && (
+                <span className={styles.mbcLabel}>BOOL</span>
+              )}
+              <button
+                ref={triggerRef}
+                type="button"
+                className={styles.modboxStateButton}
+                aria-expanded={expanded}
+                aria-label="Toggle Modbox state detail"
+                onClick={() => setExpanded((v) => !v)}
+              >
+                <span className={styles.modboxStatePill} data-tone={tone}>
+                  <span className={styles.modboxStateCount}>
+                    {okCount}/{total}
+                  </span>
+                  <span
+                    className={styles.cornerTriangle}
+                    data-expanded={expanded || undefined}
+                    aria-hidden
+                  />
+                </span>
+              </button>
             </span>
-          </button>
-        }
-        action={
-          hasModboxActions ? (
-            <CogToggle ariaLabel="Modbox actions">
-              {can('MODBOX_ON') && (
-                <ActionButton
-                  label="Set Modbox ON"
-                  pvName={pv.cmd(laser, 'MODBOX_ON')}
-                />
-              )}
-              {can('MODBOX_OFF') && (
-                <ActionButton
-                  label="Set Modbox OFF"
-                  pvName={pv.cmd(laser, 'MODBOX_OFF')}
-                  variant="secondary"
-                />
-              )}
-            </CogToggle>
-          ) : undefined
+            {mbc1Pv && (
+              <span className={styles.mbcCol}>
+                <span className={styles.mbcLabel}>MBC1</span>
+                <span className={styles.mbcCell}>
+                  <FloatValue
+                    data={state[mbc1Pv] as Message<number | null> | undefined}
+                    precision={2}
+                  />
+                </span>
+              </span>
+            )}
+            {mbc2Pv && (
+              <span className={styles.mbcCol}>
+                <span className={styles.mbcLabel}>MBC2</span>
+                <span className={styles.mbcCell}>
+                  <FloatValue
+                    data={state[mbc2Pv] as Message<number | null> | undefined}
+                    precision={2}
+                  />
+                </span>
+              </span>
+            )}
+          </div>
         }
       />
       {expanded && <DetailList items={items} />}
       <DataRow
-        label="Loaded Waveform"
+        label="Waveform Preset"
         value={
           <StringValue
             data={state[loadedWaveformPv] as Message<string | null> | undefined}
@@ -125,12 +178,45 @@ export const ModboxSection: FC<ModboxSectionProps> = ({
         }
         action={
           can('LOAD_WAVEFORM') ? (
-            <CogToggle ariaLabel="Set waveform">
+            <CogToggle ariaLabel="Set waveform preset">
               <WaveformSelect laser={laser} />
             </CogToggle>
           ) : undefined
         }
       />
+      {latestWaveformPv && (
+        <DataRow
+          label="Waveform Latest"
+          value={
+            <StringValue
+              data={
+                state[latestWaveformPv] as Message<string | null> | undefined
+              }
+            />
+          }
+        />
+      )}
+
+      {hasModboxActions && (
+        <div className={styles.actionRow}>
+          <CogToggle ariaLabel="Modbox actions" inlineLabel="Modbox Actions">
+            {can('MODBOX_ON') && (
+              <ActionButton
+                label="Set Modbox ON"
+                pvName={pv.cmd(laser, 'MODBOX_ON')}
+              />
+            )}
+            {can('MODBOX_OFF') && (
+              <ActionButton
+                label="Set Modbox OFF"
+                pvName={pv.cmd(laser, 'MODBOX_OFF')}
+                variant="secondary"
+              />
+            )}
+            {hasWaveformAction && <WaveformActionDisclosure laser={laser} />}
+          </CogToggle>
+        </div>
+      )}
     </SectionCard>
   )
 }

--- a/frontend/src/components/hmi/laser-panel/OverviewBar.module.css
+++ b/frontend/src/components/hmi/laser-panel/OverviewBar.module.css
@@ -1,14 +1,14 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.125rem;
   min-width: 0;
 }
 
 .row {
   display: grid;
-  grid-template-columns: minmax(0, 4.5rem) minmax(0, 1fr);
-  gap: 0.375rem;
+  grid-template-columns: var(--hmi-label-width, 13rem) minmax(0, 1fr);
+  gap: var(--hmi-column-gap, 0.375rem);
   align-items: center;
 }
 
@@ -34,8 +34,8 @@
 }
 
 .rowLabel {
-  font-size: 0.8125rem;
-  font-weight: 400;
+  font-size: var(--hmi-font-size);
+  font-weight: 700;
   color: var(--color-text);
   min-width: 0;
   overflow: hidden;
@@ -46,33 +46,34 @@
 .grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.25rem;
+  gap: 0.125rem;
 }
 
 .cell {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.125rem;
+  gap: 0.0625rem;
   min-width: 0;
 }
 
 .cellLabel {
-  font-size: 0.6875rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   letter-spacing: 0.04em;
   color: var(--color-text);
 }
 
 .pill {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
+  gap: 0.125rem;
   min-width: 0;
   width: 100%;
-  padding: 0.25rem 0.25rem;
-  font-size: 0.75rem;
+  padding: 0.125rem 0.1875rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   text-transform: uppercase;
@@ -131,4 +132,21 @@
   background: transparent;
   border-style: dotted;
   color: var(--color-gray-800);
+}
+
+/* Corner triangle marking an expandable element (replaces the old chevron). */
+.cornerTriangle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-bottom: 0.5rem solid var(--color-text);
+  border-left: 0.5rem solid transparent;
+  pointer-events: none;
+  opacity: 0.75;
+}
+
+.cornerTriangle[data-expanded] {
+  opacity: 1;
 }

--- a/frontend/src/components/hmi/laser-panel/OverviewBar.tsx
+++ b/frontend/src/components/hmi/laser-panel/OverviewBar.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { FC, ReactNode, useMemo, useState } from 'react'
+import { FC, ReactNode, useMemo, useRef, useState } from 'react'
 import { useWebSocketData } from '@/lib/websocket/use-websocket-data'
 import {
   DetailList,
   DetailListItem,
 } from '@/components/hmi/controls/DetailList'
-import { ChevronIcon } from '@/components/ui/icons'
 import type { LabeledPv } from '@/app/(modules)/l4-opcpa/config/schema'
+import { useCollapseOnAnyClick } from './use-collapse-on-any-click'
 import styles from './OverviewBar.module.css'
 
 interface OverviewBarProps {
@@ -19,6 +19,9 @@ interface OverviewBarProps {
 }
 
 type Expanded = 'mss' | 'err' | null
+
+const MSS_NOTE =
+  'This is a selection of some MSS indicators, it is NOT an exhaustive list of all parameters that lead to the overall MSS indicator.'
 
 /**
  * Four-cell header cluster at the top of the General box per the Confluence
@@ -33,6 +36,12 @@ export const OverviewBar: FC<OverviewBarProps> = ({
   moduleErrors,
 }) => {
   const [expanded, setExpanded] = useState<Expanded>(null)
+  const triggerRef = useRef<HTMLDivElement | null>(null)
+  useCollapseOnAnyClick(
+    expanded !== null,
+    () => setExpanded(null),
+    triggerRef,
+  )
 
   const moduleErrorPvs = useMemo(
     () => moduleErrors.map((m) => m.pv),
@@ -94,7 +103,7 @@ export const OverviewBar: FC<OverviewBarProps> = ({
     <div className={styles.wrapper}>
       <div className={styles.row}>
         <span className={styles.rowLabel}>Overview</span>
-        <div className={styles.grid}>
+        <div className={styles.grid} ref={triggerRef}>
           <Cell label="CONN">
             <OverviewBoolCell value={connMsg?.value} onText="YES" offText="NO" />
           </Cell>
@@ -114,9 +123,14 @@ export const OverviewBar: FC<OverviewBarProps> = ({
               aria-label="Toggle MSS detail"
               onClick={() => toggle('mss')}
             >
-              <CountPill
-                count={mssOk}
-                total={mssTotal}
+              <OverallPill
+                text={
+                  mssTotal === 0 || mssUnknown === mssTotal
+                    ? '<>'
+                    : mssOk === mssTotal
+                      ? 'YES'
+                      : 'NO'
+                }
                 tone={
                   mssTotal === 0 || mssUnknown === mssTotal
                     ? 'unknown'
@@ -154,7 +168,9 @@ export const OverviewBar: FC<OverviewBarProps> = ({
           </Cell>
         </div>
       </div>
-      {expanded === 'mss' && <DetailList items={mssItems} />}
+      {expanded === 'mss' && (
+        <DetailList items={mssItems} note={MSS_NOTE} />
+      )}
       {expanded === 'err' && <DetailList items={errItems} />}
     </div>
   )
@@ -223,12 +239,41 @@ const CountPill: FC<{
   return (
     <span className={styles.pill} data-tone={tone}>
       <span className={styles.pillCount}>
-        {count} / {total}
+        {count}/{total}
       </span>
       {expandable && (
-        <span className={styles.chevron}>
-          <ChevronIcon expanded={expanded} />
-        </span>
+        <span
+          className={styles.cornerTriangle}
+          data-expanded={expanded || undefined}
+          aria-hidden
+        />
+      )}
+    </span>
+  )
+}
+
+// Overall boolean indicator (e.g. MSS): renders a single YES/NO/<> word, never
+// a count. Spec: "MSS overall states must be shown as YES/NO, not numbers."
+// Keeps the expand affordance so the per-indicator DetailList still opens.
+const OverallPill: FC<{
+  text: string
+  tone:
+    | 'positive-important'
+    | 'positive-neutral'
+    | 'negative-important'
+    | 'unknown'
+  expandable?: boolean
+  expanded?: boolean
+}> = ({ text, tone, expandable, expanded }) => {
+  return (
+    <span className={styles.pill} data-tone={tone}>
+      <span className={styles.pillCount}>{text}</span>
+      {expandable && (
+        <span
+          className={styles.cornerTriangle}
+          data-expanded={expanded || undefined}
+          aria-hidden
+        />
       )}
     </span>
   )

--- a/frontend/src/components/hmi/laser-panel/SequencerSection.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/SequencerSection.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, act, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SequencerSection, L4_OPCPA_SEQUENCES } from './SequencerSection'
+import {
+  makeFakeWebSocketContext,
+  TestWebSocketProvider,
+} from '@/test/ws-test-provider'
+
+beforeEach(() => {
+  vi.stubEnv('NEXT_PUBLIC_API_URL', 'localhost:8080')
+})
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+// Build the same labeled descriptors the instance builds for NL2.
+const SEQUENCES = L4_OPCPA_SEQUENCES.map((s) => ({
+  label: s.label,
+  statePv: `BI_NL2_SEQ_${s.id}`,
+}))
+
+function renderSequencer() {
+  const ws = makeFakeWebSocketContext()
+  render(
+    <TestWebSocketProvider value={ws.context}>
+      <SequencerSection
+        sequencerRunningPv="BI_NL2_SEQUENCER_RUNNING"
+        sequences={SEQUENCES}
+      />
+    </TestWebSocketProvider>,
+  )
+  return ws
+}
+
+describe('SequencerSection', () => {
+  it('shows IDLE / RUNNING from the running PV', async () => {
+    const ws = renderSequencer()
+    await waitFor(() =>
+      expect(ws.subscriptions.get('BI_NL2_SEQUENCER_RUNNING')?.size).toBe(1),
+    )
+
+    expect(screen.getByText('Sequencer')).toBeInTheDocument()
+
+    act(() => ws.push('BI_NL2_SEQUENCER_RUNNING', 0))
+    expect(screen.getByText('IDLE')).toBeInTheDocument()
+
+    act(() => ws.push('BI_NL2_SEQUENCER_RUNNING', 1))
+    expect(screen.getByText('RUNNING')).toBeInTheDocument()
+  })
+
+  it('subscribes to a per-sequence state PV for every sequence', async () => {
+    const ws = renderSequencer()
+    await waitFor(() =>
+      expect(ws.subscriptions.get('BI_NL2_SEQ_START_LASER')?.size).toBe(1),
+    )
+    expect(ws.subscriptions.get('BI_NL2_SEQ_FLASHLAMPS_RUN')?.size).toBe(1)
+  })
+
+  it('expands to list each sequence with its individual IDLE/RUNNING state', async () => {
+    const ws = renderSequencer()
+    await waitFor(() =>
+      expect(ws.subscriptions.get('BI_NL2_SEQUENCER_RUNNING')?.size).toBe(1),
+    )
+    const user = userEvent.setup()
+
+    // Per-sequence states: Start Laser RUNNING, the rest IDLE.
+    act(() => {
+      ws.push('BI_NL2_SEQ_START_LASER', 1)
+      ws.push('BI_NL2_SEQ_STOP_LASER', 0)
+    })
+
+    expect(screen.queryByText('Start Laser')).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Toggle Sequencer detail' }),
+    )
+
+    // Each sequence row shows its label and a state badge.
+    const startRow = screen.getByText('Start Laser').closest('li')!
+    expect(within(startRow).getByText('RUNNING')).toBeInTheDocument()
+
+    const stopRow = screen.getByText('Stop Laser').closest('li')!
+    expect(within(stopRow).getByText('IDLE')).toBeInTheDocument()
+
+    // Click outside collapses it.
+    await user.click(document.body)
+    expect(screen.queryByText('Start Laser')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/hmi/laser-panel/SequencerSection.tsx
+++ b/frontend/src/components/hmi/laser-panel/SequencerSection.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { FC, useMemo, useRef, useState } from 'react'
+import { SectionCard } from '@/components/hmi/controls/SectionCard'
+import { DataRow } from '@/components/hmi/controls/DataRow'
+import { useWebSocketData } from '@/lib/websocket/use-websocket-data'
+import { useCollapseOnAnyClick } from './use-collapse-on-any-click'
+import styles from './sections.module.css'
+
+/** One sequence shown in the expanded Sequencer list. */
+export interface SequenceDescriptor {
+  /** Human-readable name (e.g. "Start Laser"). */
+  label: string
+  /** PV carrying this sequence's state (1 = RUNNING, 0 = IDLE). */
+  statePv: string
+}
+
+interface SequencerSectionProps {
+  /** Sequencer running bool PV (1 = RUNNING, 0 = IDLE). */
+  sequencerRunningPv: string
+  /** Sequences shown (with per-sequence state PV) when expanded. */
+  sequences: readonly SequenceDescriptor[]
+}
+
+/**
+ * Default sequence set for L4 OPCPA, mapped to the backend sequence commands
+ * (see LASER_COMMANDS / l4_opcpa.go `sequences`). The `id` is the command id;
+ * the per-sequence state PV is derived from it via `pv.seqState`.
+ *
+ * Spec ("Sequencer"): a boolean IDLE/RUNNING that, on click, expands to a list
+ * of all sequences with their individual state. The per-sequence state is a
+ * proof-of-concept mock (no real per-sequence PV exists yet) — see pv.seqState.
+ */
+export const L4_OPCPA_SEQUENCES = [
+  { label: 'Start Laser', id: 'START_LASER' },
+  { label: 'Stop Laser', id: 'STOP_LASER' },
+  { label: 'Set to Alignment Mode', id: 'ALIGNMENT_MODE' },
+  { label: 'Set to System Standby', id: 'SYSTEM_STANDBY' },
+  { label: 'Set All Flashlamps to Run', id: 'FLASHLAMPS_RUN' },
+  { label: 'Set All Flashlamps to Standby', id: 'FLASHLAMPS_STANDBY' },
+] as const
+
+/**
+ * Sequencer status. A single state pill (RUNNING / IDLE) that expands — per the
+ * spec, the Sequencer is an expandable element — to list every sequence with
+ * its own IDLE/RUNNING state. Collapses on any click in the app.
+ */
+export const SequencerSection: FC<SequencerSectionProps> = ({
+  sequencerRunningPv,
+  sequences,
+}) => {
+  const [expanded, setExpanded] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  useCollapseOnAnyClick(expanded, () => setExpanded(false), triggerRef)
+
+  const pvs = useMemo(
+    () => [sequencerRunningPv, ...sequences.map((s) => s.statePv)],
+    [sequencerRunningPv, sequences],
+  )
+  const { state } = useWebSocketData<number | null>({ pvs, raw: true })
+
+  const msg = state[sequencerRunningPv]
+  const running = !msg || !msg.ok || msg.value === null ? null : msg.value === 1
+
+  const label = running === null ? '<>' : running ? 'RUNNING' : 'IDLE'
+  const tone =
+    running === null
+      ? 'unknown'
+      : running
+        ? 'positive-important'
+        : 'negative-neutral'
+
+  return (
+    <SectionCard>
+      <DataRow
+        label="Sequencer"
+        valueVariant="bare"
+        value={
+          <button
+            ref={triggerRef}
+            type="button"
+            className={styles.modboxStateButton}
+            aria-expanded={expanded}
+            aria-label="Toggle Sequencer detail"
+            onClick={() => setExpanded((v) => !v)}
+          >
+            <span className={styles.modboxStatePill} data-tone={tone}>
+              <span className={styles.modboxStateCount}>{label}</span>
+              <span
+                className={styles.cornerTriangle}
+                data-expanded={expanded || undefined}
+                aria-hidden
+              />
+            </span>
+          </button>
+        }
+      />
+      {expanded && (
+        <ul className={styles.sequenceList}>
+          {sequences.map(({ label: name, statePv }) => {
+            const m = state[statePv]
+            const seqRunning =
+              !m || !m.ok || m.value === null ? null : m.value === 1
+            const seqText =
+              seqRunning === null ? '<>' : seqRunning ? 'RUNNING' : 'IDLE'
+            const seqTone =
+              seqRunning === null
+                ? 'unknown'
+                : seqRunning
+                  ? 'positive-important'
+                  : 'negative-neutral'
+            return (
+              <li key={statePv} className={styles.sequenceItem}>
+                <span>{name}</span>
+                <span className={styles.sequenceState} data-tone={seqTone}>
+                  {seqText}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </SectionCard>
+  )
+}

--- a/frontend/src/components/hmi/laser-panel/WaveformSelect.module.css
+++ b/frontend/src/components/hmi/laser-panel/WaveformSelect.module.css
@@ -6,7 +6,7 @@
 
 .select {
   font: inherit;
-  font-size: 0.8125rem;
+  font-size: var(--hmi-font-size);
   padding: 0.25rem 0.375rem;
   border-radius: 0;
   border: 1px solid var(--color-text);
@@ -16,10 +16,8 @@
 
 .load {
   font: inherit;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
   padding: 0.25rem 0.5rem;
   border-radius: 0;
   border: 1px solid var(--color-text);
@@ -37,32 +35,20 @@
   cursor: not-allowed;
 }
 
-.load:not(:disabled) {
-  border-color: var(--color-success-dark);
-  color: var(--color-success-dark);
-  border-width: 2px;
-  padding: calc(0.25rem - 1px) calc(0.5rem - 1px);
-}
-
 .load[data-state='pending'] {
   border-style: dashed;
   background: var(--color-surface-light);
-  color: var(--color-text);
-  border-color: var(--color-text);
 }
 
 .load[data-state='error'] {
-  background: color-mix(in srgb, var(--color-error) 18%, var(--color-surface-lighter));
-  color: var(--color-error-dark);
-  border-color: var(--color-error-dark);
   border-style: double;
-  border-width: 4px;
-  padding: calc(0.25rem - 3px) calc(0.5rem - 3px);
+  border-width: 3px;
+  padding: calc(0.25rem - 2px) calc(0.5rem - 2px);
+  background: var(--color-surface-light);
 }
 
 .errorRow {
-  font-size: 0.6875rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   color: var(--color-error-dark);
-  text-transform: uppercase;
 }

--- a/frontend/src/components/hmi/laser-panel/WaveformSelect.test.tsx
+++ b/frontend/src/components/hmi/laser-panel/WaveformSelect.test.tsx
@@ -40,7 +40,7 @@ describe('WaveformSelect', () => {
     expect(screen.getByRole('option', { name: 'broad-200ps' })).toBeInTheDocument()
   })
 
-  it('disables Load until the user picks a waveform', async () => {
+  it('disables waveform setting until the user picks a waveform', async () => {
     mockFetch()
     const user = userEvent.setup()
     render(<WaveformSelect laser="NL2" />)
@@ -48,13 +48,13 @@ describe('WaveformSelect', () => {
       expect(screen.getByRole('option', { name: 'std-100ps' })).toBeInTheDocument(),
     )
 
-    expect(screen.getByRole('button', { name: /Load/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /CONFIRM/i })).toBeDisabled()
 
     await user.selectOptions(screen.getByRole('combobox'), 'narrow-50ps')
-    expect(screen.getByRole('button', { name: /Load/ })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: /CONFIRM/i })).not.toBeDisabled()
   })
 
-  it('POSTs CMD_<laser>_LOAD_WAVEFORM with the selected name on Load click', async () => {
+  it('POSTs CMD_<laser>_LOAD_WAVEFORM with the selected name on Set Waveform click', async () => {
     const spy = mockFetch()
     const user = userEvent.setup()
     render(<WaveformSelect laser="NL2" />)
@@ -63,7 +63,7 @@ describe('WaveformSelect', () => {
     )
 
     await user.selectOptions(screen.getByRole('combobox'), 'broad-200ps')
-    await user.click(screen.getByRole('button', { name: /Load/ }))
+    await user.click(screen.getByRole('button', { name: /CONFIRM/i }))
 
     await waitFor(() => {
       const seqCall = spy.mock.calls.find(([url]) =>

--- a/frontend/src/components/hmi/laser-panel/WaveformSelect.tsx
+++ b/frontend/src/components/hmi/laser-panel/WaveformSelect.tsx
@@ -68,7 +68,7 @@ export const WaveformSelect: FC<WaveformSelectProps> = ({ laser }) => {
         onChange={(e) => setSelected(e.target.value)}
         aria-label="Waveform"
       >
-        <option value="">— pick a waveform —</option>
+        <option value="">Select Waveform</option>
         {catalog.map((name) => (
           <option key={name} value={name}>
             {name}
@@ -82,7 +82,7 @@ export const WaveformSelect: FC<WaveformSelectProps> = ({ laser }) => {
         disabled={!selected || state === 'pending'}
         data-state={state}
       >
-        {state === 'pending' ? 'Loading…' : 'Load'}
+        {state === 'pending' ? 'Setting…' : 'CONFIRM'}
       </button>
       {error && <div className={styles.errorRow}>{error}</div>}
     </div>

--- a/frontend/src/components/hmi/laser-panel/chiller-cell-state.test.ts
+++ b/frontend/src/components/hmi/laser-panel/chiller-cell-state.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { deriveCellState, CHILLER_LIMITS } from './chiller-cell-state'
+import type { Message } from '@/app/providers/types'
+
+const NOW = 1_700_000_000_000 // fixed ms
+const fresh = NOW / 1000
+
+function msg(over: Partial<Message<number | null>> = {}): Message<number | null> {
+  return {
+    type: 'pv',
+    name: 'AI_NL2_CHILLER_11_FLOW',
+    value: 50,
+    severity: 0,
+    units: null,
+    timestamp: fresh,
+    ok: true,
+    error: null,
+    ...over,
+  }
+}
+
+const base = { isConnected: true, nowMs: NOW, limits: CHILLER_LIMITS.flow }
+
+describe('deriveCellState (CSI-783)', () => {
+  it('OK: finite, in-range, fresh, severity 0', () => {
+    const v = deriveCellState({ ...base, msg: msg() })
+    expect(v.kind).toBe('ok')
+    expect(v.text).toBe('50.000')
+    expect(v.actionEnabled).toBe(true)
+  })
+
+  it('device_off blocks actions regardless of value', () => {
+    const v = deriveCellState({ ...base, msg: msg(), deviceOff: true })
+    expect(v.kind).toBe('device_off')
+    expect(v.actionEnabled).toBe(false)
+    expect(v.actionBlockedReason).toMatch(/device is off/i)
+  })
+
+  it('disconnected overrides a present value', () => {
+    const v = deriveCellState({ ...base, isConnected: false, msg: msg() })
+    expect(v.kind).toBe('disconnected')
+    expect(v.text).toBe('<>')
+  })
+
+  it('unknown when no message yet', () => {
+    const v = deriveCellState({ ...base, msg: undefined })
+    expect(v.kind).toBe('unknown')
+  })
+
+  it('pv_error when ok=false (surfaces error text)', () => {
+    const v = deriveCellState({ ...base, msg: msg({ ok: false, error: 'CA disconnected' }) })
+    expect(v.kind).toBe('pv_error')
+    expect(v.title).toMatch(/CA disconnected/)
+  })
+
+  it('pv_error on INVALID severity (3) even if ok', () => {
+    expect(deriveCellState({ ...base, msg: msg({ severity: 3 }) }).kind).toBe('pv_error')
+  })
+
+  it('no_value when value is null', () => {
+    expect(deriveCellState({ ...base, msg: msg({ value: null }) }).kind).toBe('no_value')
+  })
+
+  it('invalid_type when value is not a number', () => {
+    const v = deriveCellState({
+      ...base,
+      // simulate a contract violation (string in a numeric PV)
+      msg: msg({ value: 'oops' as unknown as number }),
+    })
+    expect(v.kind).toBe('invalid_type')
+    expect(v.text).toBe('TYPE')
+  })
+
+  it('non_finite for NaN', () => {
+    expect(deriveCellState({ ...base, msg: msg({ value: NaN }) }).kind).toBe('non_finite')
+  })
+
+  it('non_finite for Infinity', () => {
+    const v = deriveCellState({ ...base, msg: msg({ value: Infinity }) })
+    expect(v.kind).toBe('non_finite')
+    expect(v.text).toBe('FAULT')
+  })
+
+  it('stale when the reading is too old', () => {
+    const old = msg({ timestamp: fresh - 999 })
+    const v = deriveCellState({ ...base, msg: old, staleSec: 10 })
+    expect(v.kind).toBe('stale')
+    expect(v.text).toBe('50.000') // still shows last value, dimmed
+  })
+
+  it('out_of_range below min and above max', () => {
+    expect(
+      deriveCellState({ ...base, msg: msg({ value: -1 }), limits: { min: 0, max: 100 } }).kind,
+    ).toBe('out_of_range')
+    expect(
+      deriveCellState({ ...base, msg: msg({ value: 999 }), limits: { min: 0, max: 100 } }).kind,
+    ).toBe('out_of_range')
+  })
+
+  it('alarm_major (sev 2) and alarm_minor (sev 1)', () => {
+    expect(deriveCellState({ ...base, msg: msg({ severity: 2 }) }).kind).toBe('alarm_major')
+    const minor = deriveCellState({ ...base, msg: msg({ severity: 1 }) })
+    expect(minor.kind).toBe('alarm_minor')
+    expect(minor.actionEnabled).toBe(true) // minor still actionable
+  })
+
+  it('disconnected takes priority over a stale/old message', () => {
+    const v = deriveCellState({
+      ...base,
+      isConnected: false,
+      msg: msg({ timestamp: fresh - 999 }),
+    })
+    expect(v.kind).toBe('disconnected')
+  })
+})

--- a/frontend/src/components/hmi/laser-panel/chiller-cell-state.ts
+++ b/frontend/src/components/hmi/laser-panel/chiller-cell-state.ts
@@ -1,0 +1,243 @@
+import type { Message } from '@/app/providers/types'
+
+/**
+ * CSI-783 — explicit component states for a Flow / Temp / Water cell.
+ *
+ * Pure logic (no React) so every branch is unit-testable. Given the latest
+ * `Message`, the transport state and per-quantity limits, it resolves exactly
+ * one {@link CellKind}. The renderer ({@link ChillerCell}) maps the result to
+ * text + tone + tooltip.
+ *
+ * NOTE on data sources: `value`, `ok`, `severity`, `error`, `timestamp` come
+ * from the gateway message; `isConnected` from the socket. `deviceOff` would
+ * come from a per-device "enabled/on" PV — that PV does NOT exist in the mock
+ * yet (open question for controls), so DEVICE_OFF / ACTION_BLOCKED are wired
+ * and tested but only trigger when such a signal is supplied.
+ */
+export type CellKind =
+  | 'ok'
+  | 'disconnected'
+  | 'unknown'
+  | 'no_value'
+  | 'stale'
+  | 'pv_error'
+  | 'invalid_type'
+  | 'non_finite'
+  | 'alarm_minor'
+  | 'alarm_major'
+  | 'out_of_range'
+  | 'device_off'
+
+export type CellTone = 'ok' | 'warn' | 'error' | 'unknown' | 'muted'
+
+export interface CellView {
+  kind: CellKind
+  /** Text shown in the cell. */
+  text: string
+  tone: CellTone
+  /** Tooltip explaining the state (hover/title). */
+  title: string
+  /** Whether an action that depends on this cell being healthy may run. */
+  actionEnabled: boolean
+  /** When actionEnabled is false, a human reason ("device off", …). */
+  actionBlockedReason?: string
+}
+
+export interface Limits {
+  min: number
+  max: number
+}
+
+/** EPICS alarm severities. */
+const SEV_MINOR = 1
+const SEV_MAJOR = 2
+const SEV_INVALID = 3
+
+const EMPTY = '<>'
+
+export interface DeriveArgs {
+  msg: Message<number | null> | undefined
+  isConnected: boolean
+  /** Now in ms (defaults to Date.now()). */
+  nowMs?: number
+  /** Max age before a reading is considered stale, in seconds. */
+  staleSec?: number
+  /** Physical limits for this quantity (out-of-range detection). */
+  limits?: Limits
+  /** From a per-device enable PV (not in the mock); true → device is off. */
+  deviceOff?: boolean
+  precision?: number
+}
+
+const fmt = (v: number, p: number) => v.toFixed(p)
+
+/**
+ * Resolve the single cell state. Order matters: hardest/most-specific failures
+ * win first, so e.g. a disconnected socket never shows a stale number as if live.
+ */
+export function deriveCellState({
+  msg,
+  isConnected,
+  nowMs = Date.now(),
+  staleSec = 10,
+  limits,
+  deviceOff = false,
+  precision = 3,
+}: DeriveArgs): CellView {
+  // 1. Device intentionally off → dependent actions blocked.
+  if (deviceOff) {
+    return {
+      kind: 'device_off',
+      text: 'OFF',
+      tone: 'muted',
+      title: 'Device is off — readings unavailable and dependent actions are disabled.',
+      actionEnabled: false,
+      actionBlockedReason: 'required device is off',
+    }
+  }
+
+  // 2. Transport down → everything is unknown/stale at the panel level.
+  if (!isConnected) {
+    return {
+      kind: 'disconnected',
+      text: EMPTY,
+      tone: 'unknown',
+      title: 'Backend disconnected — value unknown.',
+      actionEnabled: false,
+      actionBlockedReason: 'backend disconnected',
+    }
+  }
+
+  // 3. No message received yet (cold start).
+  if (!msg) {
+    return {
+      kind: 'unknown',
+      text: EMPTY,
+      tone: 'unknown',
+      title: 'Awaiting first update from PV.',
+      actionEnabled: false,
+      actionBlockedReason: 'no data yet',
+    }
+  }
+
+  // 4. Gateway flagged the PV bad, or EPICS INVALID severity.
+  if (!msg.ok || msg.severity === SEV_INVALID) {
+    return {
+      kind: 'pv_error',
+      text: 'ERR',
+      tone: 'error',
+      title: msg.error
+        ? `PV error: ${msg.error}`
+        : 'PV reported an error / INVALID severity.',
+      actionEnabled: false,
+      actionBlockedReason: 'PV in error',
+    }
+  }
+
+  // 5. Record up but no value.
+  if (msg.value === null) {
+    return {
+      kind: 'no_value',
+      text: EMPTY,
+      tone: 'unknown',
+      title: 'PV connected but no value present.',
+      actionEnabled: false,
+      actionBlockedReason: 'no value',
+    }
+  }
+
+  // 6. Value present but not a number (contract violation, incl. long strings).
+  if (typeof msg.value !== 'number') {
+    return {
+      kind: 'invalid_type',
+      text: 'TYPE',
+      tone: 'error',
+      title: `Expected a number, got ${typeof msg.value}.`,
+      actionEnabled: false,
+      actionBlockedReason: 'invalid value type',
+    }
+  }
+
+  // 7. Non-finite number (NaN / ±Infinity) — never render the raw token.
+  if (!Number.isFinite(msg.value)) {
+    return {
+      kind: 'non_finite',
+      text: 'FAULT',
+      tone: 'error',
+      title: 'Non-finite reading (NaN/Infinity).',
+      actionEnabled: false,
+      actionBlockedReason: 'faulty value',
+    }
+  }
+
+  const value = msg.value
+  const shown = fmt(value, precision)
+
+  // 8. Stale: a real-looking value that hasn't refreshed. timestamp is seconds.
+  if (Number.isFinite(msg.timestamp) && msg.timestamp > 0) {
+    const ageSec = nowMs / 1000 - msg.timestamp
+    if (ageSec > staleSec) {
+      return {
+        kind: 'stale',
+        text: shown,
+        tone: 'muted',
+        title: `Stale: last update ${Math.round(ageSec)}s ago.`,
+        actionEnabled: false,
+        actionBlockedReason: 'reading is stale',
+      }
+    }
+  }
+
+  // 9. Out of physical range.
+  if (limits && (value < limits.min || value > limits.max)) {
+    return {
+      kind: 'out_of_range',
+      text: shown,
+      tone: 'error',
+      title: `Out of range (${limits.min}–${limits.max}).`,
+      actionEnabled: false,
+      actionBlockedReason: 'reading out of range',
+    }
+  }
+
+  // 10. EPICS alarm on an otherwise valid number.
+  if (msg.severity === SEV_MAJOR) {
+    return {
+      kind: 'alarm_major',
+      text: shown,
+      tone: 'error',
+      title: 'MAJOR alarm severity.',
+      actionEnabled: false,
+      actionBlockedReason: 'major alarm',
+    }
+  }
+  if (msg.severity === SEV_MINOR) {
+    return {
+      kind: 'alarm_minor',
+      text: shown,
+      tone: 'warn',
+      title: 'MINOR alarm severity.',
+      actionEnabled: true,
+    }
+  }
+
+  // 11. Healthy.
+  return {
+    kind: 'ok',
+    text: shown,
+    tone: 'ok',
+    title: 'OK.',
+    actionEnabled: true,
+  }
+}
+
+/**
+ * Placeholder physical limits per quantity (PoC). Real min/max must come from
+ * controls — see CSI-783 doc open questions. Wide bounds so the mock's ~50
+ * autosim values read OK while still exercising the out-of-range branch in tests.
+ */
+export const CHILLER_LIMITS: Record<'flow' | 'temp' | 'level', Limits> = {
+  flow: { min: 0, max: 200 },
+  temp: { min: -50, max: 150 },
+  level: { min: 0, max: 100 },
+}

--- a/frontend/src/components/hmi/laser-panel/sections.module.css
+++ b/frontend/src/components/hmi/laser-panel/sections.module.css
@@ -1,13 +1,25 @@
 .actionRow {
-  display: flex;
-  justify-content: flex-end;
-  padding-top: 0.25rem;
+  display: grid;
+  grid-template-columns: var(--hmi-label-width, 13rem) minmax(0, 1fr);
+  gap: var(--hmi-column-gap, 0.375rem);
+  align-items: center;
+  padding-top: 0.125rem;
+}
+
+.actionRow > span {
+  grid-column: 2;
+  width: 100%;
+}
+
+.actionRow > span > button {
+  width: 100%;
+  justify-content: flex-start;
 }
 
 .chillerGrid {
   display: grid;
-  grid-template-columns: minmax(0, 7rem) repeat(3, minmax(0, 1fr));
-  gap: 0.25rem 0.375rem;
+  grid-template-columns: var(--hmi-label-width, 13rem) repeat(3, minmax(0, 1fr));
+  gap: 0.125rem var(--hmi-column-gap, 0.375rem);
   align-items: center;
 }
 
@@ -16,16 +28,18 @@
 }
 
 .colHeader {
-  font-size: 0.6875rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   letter-spacing: 0.04em;
   color: var(--color-text);
   text-align: center;
+  white-space: nowrap;
   min-width: 0;
 }
 
 .rowLabel {
-  font-size: 0.8125rem;
+  font-size: var(--hmi-font-size);
+  font-weight: 700;
   color: var(--color-text);
   min-width: 0;
   overflow: hidden;
@@ -39,28 +53,32 @@
   justify-content: flex-end;
   background: var(--color-surface-lighter);
   border: 1px solid var(--color-border);
-  padding: 0.125rem 0.375rem;
-  min-height: 1.5rem;
+  padding: 0.0625rem 0.25rem;
+  min-height: var(--hmi-row-min-h);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
 }
 
 .flashlampStateButton {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.125rem;
   background: transparent;
   border: none;
   padding: 0;
+  padding-right: 0.9rem;
   margin: 0;
   cursor: pointer;
   font: inherit;
-  font-size: 0.8125rem;
+  font-size: var(--hmi-font-size);
+  font-weight: 700;
   color: var(--color-text);
   text-align: left;
+  width: 100%;
   min-width: 0;
 }
 
@@ -100,9 +118,20 @@
 
 .flashlampGrid {
   display: grid;
-  grid-template-columns: minmax(0, 7rem) repeat(4, minmax(0, 1fr)) auto;
-  gap: 0.25rem 0.25rem;
+  grid-template-columns:
+    var(--hmi-label-width, 13rem)
+    repeat(4, minmax(0, 1fr))
+    var(--hmi-action-width, 1.75rem);
+  gap: 0.125rem;
   align-items: center;
+}
+
+.flashlampGrid > span:last-child {
+  width: 100%;
+}
+
+.flashlampGrid > span:last-child > button {
+  width: 100%;
 }
 
 .flashlampCell {
@@ -111,12 +140,12 @@
   justify-content: center;
   background: var(--color-surface-lighter);
   border: 1px solid var(--color-text);
-  padding: 0.125rem 0.25rem;
-  min-height: 1.5rem;
+  padding: 0.0625rem 0.1875rem;
+  min-height: var(--hmi-row-min-h);
   min-width: 0;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
-  font-size: 0.75rem;
+  font-size: var(--hmi-font-size);
 }
 
 .flashlampCell[data-tone='positive-important'] {
@@ -175,13 +204,14 @@
 }
 
 .modboxStatePill {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 100%;
-  min-height: 1.5rem;
-  padding: 0.125rem 0.5rem;
-  font-size: 0.75rem;
+  min-height: var(--hmi-row-min-h);
+  padding: 0.0625rem 0.25rem;
+  font-size: var(--hmi-font-size);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   background: var(--color-surface-lighter);
@@ -208,4 +238,203 @@
   background: transparent;
   border-style: dotted;
   color: var(--color-gray-800);
+}
+
+/* Corner triangle marking an expandable element (replaces the old chevron). */
+.cornerTriangle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-bottom: 0.5rem solid var(--color-text);
+  border-left: 0.5rem solid transparent;
+  pointer-events: none;
+  opacity: 0.75;
+}
+
+.cornerTriangle[data-expanded] {
+  opacity: 1;
+}
+
+/* Sequencer expandable list */
+.sequenceList {
+  list-style: none;
+  margin: 0;
+  padding: 0.125rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.0625rem;
+  font-size: var(--hmi-font-size);
+  background: var(--color-surface-lighter);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.sequenceItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.25rem;
+  padding: 0.0625rem 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sequenceState {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Equal-width state chip (CSI-754): min-width must hold the *longest* label
+     so IDLE / RUNNING / <> all render at the same width. "RUNNING" measures
+     ~59px at --hmi-font-size (RobotoCondensed-Bold, 0.8125rem, border-box +
+     0.375rem padding). The previous 8ch (~46px) was too small — "RUNNING"
+     overflowed it and grew wider than IDLE, so the two badges were unequal.
+     11ch (~63px) contains "RUNNING" with margin; unit stays font-relative so
+     it tracks the CSI-782 font-size token. */
+  min-width: 11ch;
+  min-height: 1.125rem;
+  font-weight: 700;
+  font-size: var(--hmi-font-size);
+  letter-spacing: 0.04em;
+  padding: 0 0.375rem;
+  text-align: center;
+  border: 1px solid var(--color-text);
+}
+
+.sequenceState[data-tone='positive-important'] {
+  background: var(--color-success);
+  border-color: var(--color-success-dark);
+}
+
+.sequenceState[data-tone='negative-neutral'] {
+  background: var(--color-surface);
+  border-color: var(--color-gray-800);
+}
+
+.sequenceState[data-tone='unknown'] {
+  background: transparent;
+  border-style: dotted;
+  color: var(--color-gray-800);
+}
+
+/* Modbox MBC sub-readouts on the Modbox State row */
+.modboxRow {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: end;
+  gap: 0.125rem;
+  width: 100%;
+  min-width: 0;
+}
+
+.modboxRow[data-layout='bool-only'] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.modboxRow .modboxStateButton {
+  width: 100%;
+}
+
+.modboxRow .modboxStatePill {
+  width: 100%;
+  min-width: 0;
+  padding-right: 0.9rem; /* room for the corner triangle */
+}
+
+.modboxRow .modboxStateCount {
+  overflow: hidden;
+}
+
+.mbcCell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
+  min-height: var(--hmi-row-min-h);
+  padding: 0.0625rem 0.25rem;
+  font-size: var(--hmi-font-size);
+  font-variant-numeric: tabular-nums;
+  background: var(--color-surface-lighter);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  box-sizing: border-box;
+}
+
+.mbcLabel {
+  font-size: var(--hmi-font-size);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--color-text);
+  text-align: center;
+}
+
+.mbcCol {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.0625rem;
+  width: 100%;
+  min-width: 0;
+}
+
+/* "Set Waveform to…" disclosure inside the Modbox Actions cog panel.
+ * The toggle button matches the uniform ActionButton chrome (no green/red);
+ * pressing it reveals the same waveform selectbox + CONFIRM used next to the
+ * Waveform Preset row. */
+.waveformAction {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.waveformActionToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.1875rem 0.375rem;
+  font: inherit;
+  font-size: var(--hmi-font-size);
+  font-weight: 700;
+  border-radius: 0;
+  border: 1px solid var(--color-text);
+  background: var(--color-surface-lighter);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.waveformActionToggle:hover {
+  background: var(--color-surface);
+}
+
+/* CSI-783: chiller cell state rendering. One tone per derived CellKind. */
+.cellState {
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+  font-size: var(--hmi-font-size);
+  font-weight: 700;
+  white-space: nowrap;
+}
+.cellState[data-tone='ok'] {
+  color: var(--color-text);
+}
+.cellState[data-tone='warn'] {
+  color: var(--color-text);
+  background: var(--color-warning, #facc15);
+}
+.cellState[data-tone='error'] {
+  color: var(--color-text);
+  background: var(--color-negative-important, #f87171);
+}
+.cellState[data-tone='unknown'] {
+  color: var(--color-text-secondary);
+}
+.cellState[data-tone='muted'] {
+  color: var(--color-text-secondary);
+  font-style: italic;
 }

--- a/frontend/src/components/hmi/laser-panel/use-collapse-on-any-click.ts
+++ b/frontend/src/components/hmi/laser-panel/use-collapse-on-any-click.ts
@@ -1,0 +1,32 @@
+'use client'
+
+import { RefObject, useEffect } from 'react'
+
+/**
+ * While `expanded` is true, collapse when the user clicks anywhere in the app
+ * that is not inside the trigger element. The trigger keeps its own toggle
+ * behaviour (clicking it again closes via its own handler).
+ *
+ * Implements the spec requirement: once an element is expanded it can be
+ * collapsed by clicking anywhere. The listener is attached in an effect that
+ * runs after the opening click has finished propagating, so the click that
+ * opened the element does not immediately close it again.
+ */
+export function useCollapseOnAnyClick(
+  expanded: boolean,
+  collapse: () => void,
+  triggerRef: RefObject<HTMLElement | null>,
+): void {
+  useEffect(() => {
+    if (!expanded) return
+    const onClick = (e: MouseEvent) => {
+      const target = e.target as Node | null
+      if (target && triggerRef.current && triggerRef.current.contains(target)) {
+        return
+      }
+      collapse()
+    }
+    window.addEventListener('click', onClick)
+    return () => window.removeEventListener('click', onClick)
+  }, [expanded, collapse, triggerRef])
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,16 +2,6 @@ import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
 
-const coverageSourceGlobs = [
-  'src/lib/websocket/**/*.{ts,tsx}',
-  'src/lib/settings/**/*.{ts,tsx}',
-  'src/middleware.ts',
-  'src/components/module-page/**/*.{ts,tsx}',
-  'src/app/(modules)/l4-opcpa/**/*.{ts,tsx}',
-  'src/components/hmi/laser-panel/**/*.{ts,tsx}',
-  'src/components/hmi/controls/**/*.{ts,tsx}',
-]
-
 export default defineConfig({
   plugins: [react()],
   test: {
@@ -27,8 +17,21 @@ export default defineConfig({
       // L4 OPCPA paths are explicitly added (not excluded) so the primitives
       // shipped in PR #26 (pv-names, usePvWrite, sections, etc.) participate
       // in the threshold check below.
-      include: coverageSourceGlobs,
-      exclude: ['src/test/**', '**/*.config.*', '**/types.ts', '**/index.ts'],
+      include: [
+        'src/lib/websocket/**',
+        'src/lib/settings/**',
+        'src/middleware.ts',
+        'src/components/module-page/**',
+        'src/app/(modules)/l4-opcpa/**',
+        'src/components/hmi/laser-panel/**',
+        'src/components/hmi/controls/**',
+      ],
+      exclude: [
+        'src/test/**',
+        '**/*.config.*',
+        '**/types.ts',
+        '**/index.ts',
+      ],
       thresholds: {
         lines: 70,
         functions: 70,


### PR DESCRIPTION
## What this PR does

Replaces the L4 OPCPA frontend (and its mock server) with the **field-validated NL2 snapshot build** — the version operators have been running and verifying locally. After merge, the repository app and the local snapshot app are the same app. Two commits, 53 files, +2693/−440.

1. `feat(hmi)!: replace L4 OPCPA frontend with the validated NL2 snapshot`
2. `feat(mock): sync mockup websocket server with the NL2 snapshot`

## Why a replacement

The snapshot line diverged from this repository across ~45 frontend files; cherry-picking pieces would leave a hybrid nobody has ever run. The snapshot is the tree that has been exercised, measured and bug-fixed end-to-end, and the L4 OPCPA spec states that *only one NL2 panel remains in the final UI* — which is exactly what this build renders.

## What changes visibly

- **Single NL2 panel** (spec'd end-state) instead of the current NL1–NL5 row; the five-laser view is superseded.
- Compact token-based panel layout with wider, non-truncating device labels; equal-width sequencer state badge; separate "Waveform Preset" / "Waveform Latest" rows (replacing "Loaded Waveform").
- Cog action dropdowns are portaled to `<body>` (never clipped by the scroll container; flip up near the viewport edge).
- Adaptive layout: wrapping grid, fluid root font-size `clamp(12.5px, 0.5vw + 4.5px, 18px)`, status sidebar stacks ≤640 px — one codebase from phone to 4K control-room display.
- New components arrive with tests: `SequencerSection`, `ChillerCell`/`chiller-cell-state`, `use-collapse-on-any-click`.

## What is deliberately preserved from this repository

Build infrastructure only: `frontend/.npmrc` (internal npm mirror), `frontend/Dockerfile`, `frontend/Dockerfile.demo`, `frontend/.dockerignore`, and in the mock server its `Dockerfile` and `vendor/` (the snapshot's `go.mod`/`go.sum` are byte-identical to upstream's, so vendoring stays consistent). No CI, docs, or other backend services are touched.

## Verification (all on this exact branch)

`tsc` clean · `eslint` clean · **vitest 27 files / 152 tests passing** · `next build` clean · `go build` / `go vet` / `go test` clean (including the mock's waveform-transition and per-sequence tests). In-browser probe of the running branch produces a rendering signature **identical** to the snapshot build: one NL2 panel, 275 px at the 12.5 px fluid base, all 11 row labels fully visible, zero truncation; screenshots attached. Dependency install was verified against the public registry with lockfile integrity hashes (outside the ELI network); the preserved `.npmrc` with `replace-registry-host=always` keeps `npm ci` working on the internal mirror.

## Risk & rollback

This intentionally supersedes upstream's variants of the 45 replaced files — review the diff for anything that must survive. The change is two ordinary commits on a branch: reverting the PR (or the two commits) restores today's `dev` exactly. Nothing is force-pushed.

## Note

This PR supersedes the earlier three-commit fix series (dropdown portal, font fallbacks, adaptive layout) — all three are contained in this snapshot.
