### PR TITLE
Override postcss and uuid to fix the last 2 Dependabot alerts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7352,8 +7352,8 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.16",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7370,9 +7370,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -8782,11 +8782,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -8876,34 +8880,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.16",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,5 +48,13 @@
     "typescript": "^6",
     "vitest": "^4.1.5",
     "vitest-websocket-mock": "^0.5.0"
+  },
+  "overrides": {
+    "next": {
+      "postcss": "^8.5.10"
+    },
+    "next-auth": {
+      "uuid": "^11.1.1"
+    }
   }
 }


### PR DESCRIPTION

Clears the final 2 open Dependabot security alerts (both medium, `frontend/package-lock.json`). Together with #51 this brings open alerts from 21 to 0.

- `postcss` 8.4.31 → **8.5.16** — GHSA: XSS via unescaped `</style>` in stringify output (patched in 8.5.10). Pinned exactly by `next`, so raised with a scoped override.
- `uuid` 8.3.2 → **11.1.1** — GHSA: missing buffer bounds check in `v3()`/`v5()`/`v6()` (patched in 11.1.1). Pinned `^8.3.2` by `next-auth`, raised with a scoped override.

Implementation: an `overrides` block in `package.json`, scoped to `next` and `next-auth` only, plus the regenerated lockfile. The lockfile remains registry-agnostic (no resolved URLs), so it installs from the ELI mirror and the public registry alike.

Why this is safe:
- next-auth only calls `uuid.v4()` (JWT id in `next-auth/jwt`); the APIs changed by the advisory (v3/v5/v6) are unused in the entire tree, and `v4()` is API-identical in uuid 11. CJS import verified.
- postcss 8.4→8.5 is semver-minor; vite in this same tree already bundles 8.5.16.

Validation:
- Vitest: 27/27 files, 152/152 tests pass; coverage 89/87/91/92 vs the 70/70/70/60 CI gate.
- `next build` succeeds (CSS pipeline exercised with new postcss).
- Real end-to-end login (`test`/`test` against the mock backend): session JWT issued through next-auth running uuid 11, `/api/auth/session` returns the authenticated user with a valid accessToken.
