### PR TITLE
L4 OPCPA: update goggles status colors

### DIFF
--- a/backend/mockup-websocket-server/main.go
+++ b/backend/mockup-websocket-server/main.go
@@ -42,7 +42,11 @@ func pvNamesFrom(raw json.RawMessage) []string {
 	var legacy map[string]interface{}
 	if err := json.Unmarshal(raw, &legacy); err == nil {
 		list = make([]string, 0, len(legacy))
-		for name := range legacy {
+		for name, wanted := range legacy {
+			// {"AI_X": false} means "not this one", as in the Python gateway.
+			if wanted == false {
+				continue
+			}
 			list = append(list, name)
 		}
 		return list
@@ -168,10 +172,7 @@ func (ps *pvSim) loop(ctx context.Context) {
 				ps.value = simStepFrom(ps.name, ps.value)
 				b := ps.encodeLocked()
 				for cl := range ps.subs {
-					select {
-					case cl.writeCh <- b:
-					default:
-					}
+					cl.enqueue(b)
 				}
 				ps.mu.Unlock()
 			}
@@ -227,28 +228,31 @@ func (ps *pvSim) encodeLocked() []byte {
 func (ps *pvSim) add(cl *client) {
 	ps.mu.Lock()
 	ps.subs[cl] = struct{}{}
-	b := ps.encodeLocked() // send current value immediately
+	// Queue the snapshot while still holding the lock so it can never be
+	// overtaken by an update produced by the sim loop in between.
+	cl.enqueue(ps.encodeLocked())
 	ps.mu.Unlock()
-
-	// non-blocking send
-	select {
-	case cl.writeCh <- b:
-	default:
-	}
 }
 
+// snapshot re-sends the current value to an already-attached client. The
+// gateway sends one snapshot per subscription, so a PV that a second
+// subscription group starts monitoring gets its own initial value.
+func (ps *pvSim) snapshot(cl *client) {
+	ps.mu.Lock()
+	cl.enqueue(ps.encodeLocked())
+	ps.mu.Unlock()
+}
+
+// remove detaches a client. The simulator itself stays in the registry with
+// its current value: a real IOC keeps serving a PV when nobody is monitoring
+// it, and the frontend's partial-removal flow (unsubscribe the whole group,
+// then re-subscribe the survivors) would otherwise drop every sim in the group
+// and rebuild it from a random synthValue — turning seeded state such as
+// BI_<laser>_ERR_* = 0 into a phantom module error.
 func (ps *pvSim) remove(cl *client) {
 	ps.mu.Lock()
 	delete(ps.subs, cl)
-	empty := len(ps.subs) == 0
 	ps.mu.Unlock()
-
-	if empty {
-		ps.cancel()
-		pvRegistryMu.Lock()
-		delete(pvRegistry, ps.name)
-		pvRegistryMu.Unlock()
-	}
 }
 
 func (ps *pvSim) setManualValue(v interface{}, errorMsg string) {
@@ -266,22 +270,169 @@ func (ps *pvSim) setManualValueHeld(v interface{}, errorMsg string, hold time.Du
 	}
 	b := ps.encodeLocked()
 	for cl := range ps.subs {
-		select {
-		case cl.writeCh <- b:
-		default:
-		}
+		cl.enqueue(b)
 	}
 	ps.mu.Unlock()
 }
 
 /* ---------------------- per-connection state ----------------------------- */
 
+// maxOutbox caps the per-connection queue. It is a safety valve for a socket
+// that has stopped draining entirely, not a normal-operation limit.
+const maxOutbox = 8192
+
+// clientSub is one client's attachment to a simulator, reference-counted over
+// the subscription groups that asked for the PV.
+type clientSub struct {
+	sim  *pvSim
+	refs int
+}
+
 type client struct {
-	writeCh   chan []byte
-	subs      map[string]*pvSim
-	groups    map[string]map[string]struct{}
+	// mu/cond/outbox/closed guard the outbound queue; every other field is
+	// owned by the connection's reader goroutine and needs no locking.
+	mu     sync.Mutex
+	cond   *sync.Cond
+	outbox [][]byte
+	closed bool
+
+	// subs: PV name -> attachment. groups: subscription_id -> PV names.
+	subs   map[string]*clientSub
+	groups map[string]map[string]struct{}
+
 	username  string
 	clientKey string
+}
+
+func newClient(username, clientKey string) *client {
+	cl := &client{
+		subs:      make(map[string]*clientSub),
+		groups:    make(map[string]map[string]struct{}),
+		username:  username,
+		clientKey: clientKey,
+	}
+	cl.cond = sync.NewCond(&cl.mu)
+	return cl
+}
+
+// enqueue hands one frame to the writer goroutine. It never blocks (sim loops
+// call it while holding the PV lock) and, unlike the previous fixed-size
+// channel with a non-blocking send, never silently drops a frame: a dashboard
+// subscribing to a few hundred PVs at once used to lose the tail of its
+// initial snapshots.
+func (cl *client) enqueue(b []byte) {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	if cl.closed {
+		return
+	}
+	if len(cl.outbox) >= maxOutbox {
+		// Socket is not draining at all — drop the oldest half so the mock
+		// cannot grow without bound (and so the shift is not paid per frame).
+		drop := len(cl.outbox) / 2
+		cl.outbox = append(cl.outbox[:0], cl.outbox[drop:]...)
+		log.Printf("ws client %s outbox full, dropped %d stale frames", cl.clientKey, drop)
+	}
+	cl.outbox = append(cl.outbox, b)
+	cl.cond.Signal()
+}
+
+// drain blocks until frames are queued and returns them all; it returns nil
+// once the client is closed and the queue has been emptied.
+func (cl *client) drain() [][]byte {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	for len(cl.outbox) == 0 && !cl.closed {
+		cl.cond.Wait()
+	}
+	batch := cl.outbox
+	cl.outbox = nil
+	return batch
+}
+
+func (cl *client) close() {
+	cl.mu.Lock()
+	cl.closed = true
+	cl.mu.Unlock()
+	cl.cond.Broadcast()
+}
+
+// legacySubscriptionID models the legacy per-PV protocol (a `pvs` map and no
+// subscription_id) as one single-PV subscription per PV, exactly like the
+// Python gateway does.
+func legacySubscriptionID(pv string) string { return "legacy:" + pv }
+
+// subscribeGroup makes subscriptionID monitor exactly pvs. An existing group
+// with that id is unsubscribed first (the Python gateway does the same), so
+// re-using an id cannot leak the PVs that were dropped from it.
+func (cl *client) subscribeGroup(subscriptionID string, pvs []string) {
+	cl.unsubscribeGroup(subscriptionID)
+
+	group := make(map[string]struct{}, len(pvs))
+	cl.groups[subscriptionID] = group
+	for _, pvName := range pvs {
+		pv := strings.TrimSpace(pvName)
+		if pv == "" {
+			continue
+		}
+		if _, dup := group[pv]; dup {
+			continue
+		}
+		group[pv] = struct{}{}
+		cl.retain(pv)
+	}
+}
+
+// unsubscribeGroup drops one subscription group and detaches from every PV
+// that no other group of this client still references. Reports whether the
+// group existed.
+func (cl *client) unsubscribeGroup(subscriptionID string) bool {
+	group, ok := cl.groups[subscriptionID]
+	if !ok {
+		return false
+	}
+	delete(cl.groups, subscriptionID)
+	for pv := range group {
+		cl.release(pv)
+	}
+	return true
+}
+
+func (cl *client) unsubscribeAll() {
+	for subscriptionID := range cl.groups {
+		cl.unsubscribeGroup(subscriptionID)
+	}
+	// Defensive: a bookkeeping slip must never leave the client attached to a
+	// simulator after the connection is gone.
+	for pv, sub := range cl.subs {
+		sub.sim.remove(cl)
+		delete(cl.subs, pv)
+	}
+}
+
+func (cl *client) retain(pv string) {
+	sub := cl.subs[pv]
+	if sub == nil {
+		sub = &clientSub{sim: getOrCreateSim(pv)}
+		cl.subs[pv] = sub
+		sub.sim.add(cl)
+	} else {
+		sub.sim.snapshot(cl)
+	}
+	sub.refs++
+}
+
+func (cl *client) release(pv string) {
+	sub := cl.subs[pv]
+	if sub == nil {
+		return
+	}
+	sub.refs--
+	if sub.refs > 0 {
+		return
+	}
+	delete(cl.subs, pv)
+	sub.sim.remove(cl)
 }
 
 /* ------------------------ WebSocket handler ------------------------------ */
@@ -306,15 +457,7 @@ func wsHandler(c echo.Context) error {
 
 	clientKey := c.Request().Header.Get("Sec-Websocket-Key")
 
-	cl := &client{
-		// A dashboard can subscribe to more than 32 PVs in one batch. The old
-		// buffer silently dropped the tail of the initial snapshots.
-		writeCh:   make(chan []byte, 512),
-		subs:      make(map[string]*pvSim),
-		groups:    make(map[string]map[string]struct{}),
-		username:  actor,
-		clientKey: clientKey,
-	}
+	cl := newClient(actor, clientKey)
 	log.Printf("ws client connected actor=%s clientKey=%s", cl.username, cl.clientKey)
 
 	var wg sync.WaitGroup
@@ -323,10 +466,17 @@ func wsHandler(c echo.Context) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for msg := range cl.writeCh {
-			if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
-				cancelSocket()
-				return
+		for {
+			batch := cl.drain()
+			if len(batch) == 0 {
+				return // closed and drained
+			}
+			for _, msg := range batch {
+				if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+					cancelSocket()
+					cl.close()
+					return
+				}
 			}
 		}
 	}()
@@ -344,57 +494,33 @@ func wsHandler(c echo.Context) error {
 
 		switch req.Type {
 		case "subscribe":
-			requested := pvNamesFrom(req.PVs)
-			var group map[string]struct{}
 			if req.SubscriptionID != "" {
-				group = make(map[string]struct{}, len(requested))
-				cl.groups[req.SubscriptionID] = group
+				cl.subscribeGroup(req.SubscriptionID, pvNamesFrom(req.PVs))
+				break
 			}
-			for _, pvName := range requested {
-				pv := strings.TrimSpace(pvName)
-				if pv == "" {
-					continue
+			for _, pvName := range pvNamesFrom(req.PVs) {
+				if pv := strings.TrimSpace(pvName); pv != "" {
+					cl.subscribeGroup(legacySubscriptionID(pv), []string{pv})
 				}
-				if group != nil {
-					group[pv] = struct{}{}
-				}
-				if cl.subs[pv] != nil {
-					continue
-				}
-				ps := getOrCreateSim(pv)
-				ps.add(cl)
-				cl.subs[pv] = ps
 			}
 		case "unsubscribe":
-			requested := pvNamesFrom(req.PVs)
+			// A subscription_id addresses the whole group; any `pvs` sent
+			// alongside it is ignored, as in the Python gateway.
 			if req.SubscriptionID != "" {
-				if group := cl.groups[req.SubscriptionID]; group != nil {
-					requested = requested[:0]
-					for pv := range group {
-						requested = append(requested, pv)
-					}
-					delete(cl.groups, req.SubscriptionID)
-				}
+				cl.unsubscribeGroup(req.SubscriptionID)
+				break
 			}
-			for _, pvName := range requested {
-				pv := strings.TrimSpace(pvName)
-				if pv == "" {
-					continue
-				}
-				if ps := cl.subs[pv]; ps != nil {
-					ps.remove(cl)
-					delete(cl.subs, pv)
+			for _, pvName := range pvNamesFrom(req.PVs) {
+				if pv := strings.TrimSpace(pvName); pv != "" {
+					cl.unsubscribeGroup(legacySubscriptionID(pv))
 				}
 			}
 		}
 	}
 
 	/* teardown */
-	for pv, ps := range cl.subs {
-		ps.remove(cl)
-		delete(cl.subs, pv)
-	}
-	close(cl.writeCh)
+	cl.unsubscribeAll()
+	cl.close()
 	wg.Wait()
 	return nil
 }

--- a/backend/mockup-websocket-server/main.go
+++ b/backend/mockup-websocket-server/main.go
@@ -20,8 +20,35 @@ import (
 /* ----------------------------- payloads ---------------------------------- */
 
 type RequestMessage struct {
-	Type string                 `json:"type"` // "subscribe" | "unsubscribe"
-	PVs  map[string]interface{} `json:"pvs"`
+	Type           string          `json:"type"` // "subscribe" | "unsubscribe"
+	PVs            json.RawMessage `json:"pvs"`
+	SubscriptionID string          `json:"subscription_id"`
+}
+
+// pvNamesFrom accepts both protocol forms used by the project:
+//
+//   - current batched frontend: {"pvs": ["AI_X", "BI_Y"]}
+//   - legacy clients:           {"pvs": {"AI_X": {}, "BI_Y": {}}}
+func pvNamesFrom(raw json.RawMessage) []string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+
+	var list []string
+	if err := json.Unmarshal(raw, &list); err == nil {
+		return list
+	}
+
+	var legacy map[string]interface{}
+	if err := json.Unmarshal(raw, &legacy); err == nil {
+		list = make([]string, 0, len(legacy))
+		for name := range legacy {
+			list = append(list, name)
+		}
+		return list
+	}
+
+	return nil
 }
 
 type ResponseMessage struct {
@@ -252,6 +279,7 @@ func (ps *pvSim) setManualValueHeld(v interface{}, errorMsg string, hold time.Du
 type client struct {
 	writeCh   chan []byte
 	subs      map[string]*pvSim
+	groups    map[string]map[string]struct{}
 	username  string
 	clientKey string
 }
@@ -279,8 +307,11 @@ func wsHandler(c echo.Context) error {
 	clientKey := c.Request().Header.Get("Sec-Websocket-Key")
 
 	cl := &client{
-		writeCh:   make(chan []byte, 32),
+		// A dashboard can subscribe to more than 32 PVs in one batch. The old
+		// buffer silently dropped the tail of the initial snapshots.
+		writeCh:   make(chan []byte, 512),
 		subs:      make(map[string]*pvSim),
+		groups:    make(map[string]map[string]struct{}),
 		username:  actor,
 		clientKey: clientKey,
 	}
@@ -313,9 +344,21 @@ func wsHandler(c echo.Context) error {
 
 		switch req.Type {
 		case "subscribe":
-			for pvName, _ := range req.PVs {
+			requested := pvNamesFrom(req.PVs)
+			var group map[string]struct{}
+			if req.SubscriptionID != "" {
+				group = make(map[string]struct{}, len(requested))
+				cl.groups[req.SubscriptionID] = group
+			}
+			for _, pvName := range requested {
 				pv := strings.TrimSpace(pvName)
-				if pv == "" || cl.subs[pv] != nil {
+				if pv == "" {
+					continue
+				}
+				if group != nil {
+					group[pv] = struct{}{}
+				}
+				if cl.subs[pv] != nil {
 					continue
 				}
 				ps := getOrCreateSim(pv)
@@ -323,7 +366,17 @@ func wsHandler(c echo.Context) error {
 				cl.subs[pv] = ps
 			}
 		case "unsubscribe":
-			for pvName, _ := range req.PVs {
+			requested := pvNamesFrom(req.PVs)
+			if req.SubscriptionID != "" {
+				if group := cl.groups[req.SubscriptionID]; group != nil {
+					requested = requested[:0]
+					for pv := range group {
+						requested = append(requested, pv)
+					}
+					delete(cl.groups, req.SubscriptionID)
+				}
+			}
+			for _, pvName := range requested {
 				pv := strings.TrimSpace(pvName)
 				if pv == "" {
 					continue

--- a/backend/mockup-websocket-server/readme.md
+++ b/backend/mockup-websocket-server/readme.md
@@ -55,15 +55,37 @@ You can also pass `Authorization: Bearer <jwt>` header during the handshake.
 
 ### Subscribe
 
+Many PVs share one `subscription_id`, so a dashboard sends one frame instead of
+one per PV:
+
 ```jsonc
 // request
 {
   "type": "subscribe",
-  "pvs": { "AI_TEMP": true, "BI_DOOR": true },
+  "subscription_id": "fe-1",
+  "pvs": ["AI_TEMP", "BI_DOOR"],
 }
 ```
 
+Re-using an existing `subscription_id` replaces that subscription's PV list —
+PVs no longer listed are released.
+
 ### Unsubscribe
+
+A `subscription_id` addresses the whole subscription; any `pvs` sent alongside
+it is ignored:
+
+```jsonc
+{
+  "type": "unsubscribe",
+  "subscription_id": "fe-1",
+}
+```
+
+### Legacy per-PV form
+
+Frames without a `subscription_id` still work and are handled as one single-PV
+subscription per PV:
 
 ```jsonc
 {
@@ -136,6 +158,9 @@ If `aiMode` or `biMode` is `2` (manual-only) the simulator stops its random upda
    - updates the value (unless the prefix is in manual-only mode),
    - broadcasts one JSON blob to **all** connected WebSockets that subscribed.
 
-3. When the _last_ subscriber for a PV disconnects, the simulator shuts down and is removed from the registry.
+3. Simulators outlive their subscribers. Like a real IOC, a PV keeps its value
+   when nobody is monitoring it — otherwise the frontend's partial-removal flow
+   (unsubscribe the group, re-subscribe the survivors) would reset every seeded
+   PV to a fresh random value.
 
 That’s it—no external dependencies, no storage, perfect for demos and front-end integration tests.

--- a/backend/mockup-websocket-server/root_docs.go
+++ b/backend/mockup-websocket-server/root_docs.go
@@ -211,17 +211,19 @@ func renderRootDocsHTML() string {
         <h2>WebSocket usage</h2>
         <div class="flow-list">
           <div class="flow-step">1. Connect to <code>ws://localhost:8080/ws/pvs?auth=jwt_token_please</code>.</div>
-          <div class="flow-step">2. Send a subscribe frame such as:</div>
+          <div class="flow-step">2. Send a batched subscribe frame (one <code>subscription_id</code> for many PVs):</div>
           <pre>{
   "type": "subscribe",
-  "pvs": { "AI_TEMP": true, "BI_DOOR": true }
+  "subscription_id": "fe-1",
+  "pvs": ["AI_TEMP", "BI_DOOR"]
 }</pre>
           <div class="flow-step">3. Read <code>pv</code> messages containing <code>name</code>, <code>value</code>, <code>timestamp</code>, <code>ok</code>, and <code>units</code>.</div>
-          <div class="flow-step">4. Stop a subscription with:</div>
+          <div class="flow-step">4. Stop the whole subscription with (any <code>pvs</code> sent alongside the id is ignored):</div>
           <pre>{
   "type": "unsubscribe",
-  "pvs": { "BI_DOOR": true }
+  "subscription_id": "fe-1"
 }</pre>
+          <div class="flow-step">Re-using an id replaces its PV list. The legacy per-PV form (<code>"pvs": { "BI_DOOR": true }</code> with no <code>subscription_id</code>) is still accepted and handled as one single-PV subscription per PV.</div>
         </div>
       </article>
 
@@ -240,7 +242,7 @@ curl http://localhost:8080/mode/ai/2</pre>
         <li>The first client that mentions a PV creates a global <code>pvSim</code> instance.</li>
         <li>That simulator owns the latest value, a ticker loop, and the subscriber list.</li>
         <li>On each tick, the current value is drifted when autosimulation is enabled and then broadcast to all subscribers.</li>
-        <li>When the last subscriber disconnects, the simulator is removed from the registry.</li>
+        <li>Simulators outlive their subscribers: like a real IOC, a PV keeps its value when nobody is monitoring it.</li>
       </ul>
       <p class="muted-note">For deeper background, see the mock server README and docs in the repository. This page is intentionally a concise root-path overview.</p>
     </section>

--- a/backend/mockup-websocket-server/subscription_test.go
+++ b/backend/mockup-websocket-server/subscription_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// testWS is a websocket client with a background reader: a read deadline on a
+// gorilla connection poisons it for every later read, so the test drains
+// frames from a channel instead of timing out the socket.
+type testWS struct {
+	conn   *websocket.Conn
+	frames chan ResponseMessage
+}
+
+func dialTestWS(t *testing.T) *testWS {
+	t.Helper()
+	t.Setenv(jwtSecretEnvVar, testJWTSecret)
+
+	e := newServer()
+	ts := httptest.NewServer(e)
+	t.Cleanup(ts.Close)
+
+	headers := http.Header{}
+	headers.Set("Authorization", makeBearerToken(t, "sub-tester"))
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(ts.URL, "http")+"/ws/pvs", headers)
+	if err != nil {
+		t.Fatalf("ws dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ws := &testWS{conn: conn, frames: make(chan ResponseMessage, 4096)}
+	go func() {
+		defer close(ws.frames)
+		for {
+			_, raw, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var msg ResponseMessage
+			if err := json.Unmarshal(raw, &msg); err != nil {
+				return
+			}
+			ws.frames <- msg
+		}
+	}()
+	return ws
+}
+
+func (ws *testWS) send(t *testing.T, payload interface{}) {
+	t.Helper()
+	if err := ws.conn.WriteJSON(payload); err != nil {
+		t.Fatalf("ws write failed: %v", err)
+	}
+}
+
+// collect gathers frames for `window` and returns the last value seen per PV.
+func (ws *testWS) collect(window time.Duration) map[string]interface{} {
+	seen := make(map[string]interface{})
+	timeout := time.After(window)
+	for {
+		select {
+		case msg, ok := <-ws.frames:
+			if !ok {
+				return seen
+			}
+			seen[msg.Name] = msg.Value
+		case <-timeout:
+			return seen
+		}
+	}
+}
+
+// collectUntil gathers frames until every PV in want has been seen, or the
+// window expires (which fails the test).
+func (ws *testWS) collectUntil(t *testing.T, window time.Duration, want []string) map[string]interface{} {
+	t.Helper()
+	missing := make(map[string]struct{}, len(want))
+	for _, pv := range want {
+		missing[pv] = struct{}{}
+	}
+	seen := make(map[string]interface{})
+	timeout := time.After(window)
+	for len(missing) > 0 {
+		select {
+		case msg, ok := <-ws.frames:
+			if !ok {
+				t.Fatalf("connection closed with %d PVs still missing", len(missing))
+			}
+			seen[msg.Name] = msg.Value
+			delete(missing, msg.Name)
+		case <-timeout:
+			t.Fatalf("timed out with %d of %d PVs never delivered", len(missing), len(want))
+		}
+	}
+	return seen
+}
+
+// sync waits until the connection's reader goroutine has processed everything
+// sent so far: messages are handled in order, so the snapshot of a freshly
+// subscribed sentinel PV proves the earlier messages are done.
+// It returns everything collected on the way, so a test can assert that a PV
+// it expects to be unsubscribed produced no frame.
+func (ws *testWS) sync(t *testing.T, sentinel string) map[string]interface{} {
+	t.Helper()
+	ws.send(t, map[string]interface{}{
+		"type": "subscribe", "subscription_id": "sync-" + sentinel, "pvs": []string{sentinel},
+	})
+	return ws.collectUntil(t, 2*time.Second, []string{sentinel})
+}
+
+func simFor(t *testing.T, name string) *pvSim {
+	t.Helper()
+	pvRegistryMu.Lock()
+	defer pvRegistryMu.Unlock()
+	return pvRegistry[name]
+}
+
+// A group unsubscribe must not destroy the simulators: the frontend removes a
+// single PV by dropping the whole group and re-subscribing the survivors, and
+// the seeded values have to survive that round trip.
+func TestGroupUnsubscribeKeepsSeededValues(t *testing.T) {
+	resetPVRegistryForTest()
+	setSeed("BI_SUBTEST_ERR_A", 0)
+	setSeed("BI_SUBTEST_ERR_B", 0)
+	seededA := simFor(t, "BI_SUBTEST_ERR_A")
+
+	ws := dialTestWS(t)
+	ws.send(t, map[string]interface{}{
+		"type": "subscribe", "subscription_id": "fe-1",
+		"pvs": []string{"BI_SUBTEST_ERR_A", "BI_SUBTEST_ERR_B"},
+	})
+	ws.collectUntil(t, 2*time.Second, []string{"BI_SUBTEST_ERR_A", "BI_SUBTEST_ERR_B"})
+
+	// Partial removal, exactly as the frontend performs it.
+	ws.send(t, map[string]interface{}{"type": "unsubscribe", "subscription_id": "fe-1"})
+	ws.send(t, map[string]interface{}{
+		"type": "subscribe", "subscription_id": "fe-2", "pvs": []string{"BI_SUBTEST_ERR_A"},
+	})
+
+	frames := ws.collectUntil(t, 2*time.Second, []string{"BI_SUBTEST_ERR_A"})
+	if got, ok := frames["BI_SUBTEST_ERR_A"]; !ok || got != float64(0) {
+		t.Fatalf("expected re-subscribed PV to report its seeded 0, got %v (present=%v)", got, ok)
+	}
+	if simFor(t, "BI_SUBTEST_ERR_A") != seededA {
+		t.Fatal("simulator was destroyed and re-created by the group unsubscribe")
+	}
+	if simFor(t, "BI_SUBTEST_ERR_B") == nil {
+		t.Fatal("unsubscribed simulator was dropped from the registry")
+	}
+}
+
+// Re-using a subscription_id replaces its membership; PVs dropped from the
+// group must stop being delivered instead of leaking for the connection's life.
+func TestResubscribeSameIDReleasesDroppedPVs(t *testing.T) {
+	resetPVRegistryForTest()
+	setSeed("BI_SUBTEST_KEEP", 0)
+	setSeed("BI_SUBTEST_DROP", 0)
+
+	ws := dialTestWS(t)
+	ws.send(t, map[string]interface{}{
+		"type": "subscribe", "subscription_id": "fe-1",
+		"pvs": []string{"BI_SUBTEST_KEEP", "BI_SUBTEST_DROP"},
+	})
+	ws.send(t, map[string]interface{}{
+		"type": "subscribe", "subscription_id": "fe-1", "pvs": []string{"BI_SUBTEST_KEEP"},
+	})
+	ws.sync(t, "BI_SUBTEST_SYNC1")
+
+	// DROP is written first, so a leaked frame for it would arrive before the
+	// KEEP frame the collector waits for.
+	getOrCreateSim("BI_SUBTEST_DROP").setManualValue(1, "")
+	getOrCreateSim("BI_SUBTEST_KEEP").setManualValue(1, "")
+
+	frames := ws.collectUntil(t, 2*time.Second, []string{"BI_SUBTEST_KEEP"})
+	if _, leaked := frames["BI_SUBTEST_DROP"]; leaked {
+		t.Fatal("PV dropped from the re-subscribed group is still being delivered")
+	}
+	if frames["BI_SUBTEST_KEEP"] != float64(1) {
+		t.Fatalf("expected update for the retained PV, got %v", frames["BI_SUBTEST_KEEP"])
+	}
+}
+
+// A PV monitored by two groups must survive one of them going away.
+func TestPVSharedBetweenGroupsSurvivesOneUnsubscribe(t *testing.T) {
+	resetPVRegistryForTest()
+	setSeed("BI_SUBTEST_SHARED", 0)
+
+	ws := dialTestWS(t)
+	ws.send(t, map[string]interface{}{
+		"type": "subscribe", "subscription_id": "fe-1", "pvs": []string{"BI_SUBTEST_SHARED"},
+	})
+	ws.send(t, map[string]interface{}{
+		"type": "subscribe", "subscription_id": "fe-2", "pvs": []string{"BI_SUBTEST_SHARED"},
+	})
+	ws.send(t, map[string]interface{}{"type": "unsubscribe", "subscription_id": "fe-1"})
+	ws.sync(t, "BI_SUBTEST_SYNC2")
+
+	getOrCreateSim("BI_SUBTEST_SHARED").setManualValue(1, "")
+
+	frames := ws.collectUntil(t, 2*time.Second, []string{"BI_SUBTEST_SHARED"})
+	if frames["BI_SUBTEST_SHARED"] != float64(1) {
+		t.Fatalf("PV still held by fe-2 stopped updating after fe-1 unsubscribed: %v", frames)
+	}
+}
+
+// The legacy per-PV protocol (map payload, no subscription_id) still works.
+func TestLegacyPerPVProtocol(t *testing.T) {
+	resetPVRegistryForTest()
+	setSeed("BI_SUBTEST_LEGACY", 0)
+
+	ws := dialTestWS(t)
+	ws.send(t, map[string]interface{}{
+		"type": "subscribe", "pvs": map[string]interface{}{"BI_SUBTEST_LEGACY": true},
+	})
+	ws.sync(t, "BI_SUBTEST_SYNC3")
+
+	getOrCreateSim("BI_SUBTEST_LEGACY").setManualValue(1, "")
+	if frames := ws.collectUntil(t, 2*time.Second, []string{"BI_SUBTEST_LEGACY"}); frames["BI_SUBTEST_LEGACY"] != float64(1) {
+		t.Fatalf("legacy subscribe delivered no update: %v", frames)
+	}
+
+	ws.send(t, map[string]interface{}{
+		"type": "unsubscribe", "pvs": map[string]interface{}{"BI_SUBTEST_LEGACY": true},
+	})
+	ws.sync(t, "BI_SUBTEST_SYNC4")
+
+	getOrCreateSim("BI_SUBTEST_LEGACY").setManualValue(0, "")
+	if frames := ws.sync(t, "BI_SUBTEST_SYNC5"); len(frames) != 1 {
+		t.Fatalf("legacy unsubscribe left the PV subscribed: %v", frames)
+	}
+}
+
+// Every snapshot of a large batch must arrive — the old 32-slot channel with a
+// non-blocking send silently dropped the tail.
+func TestLargeBatchDeliversEverySnapshot(t *testing.T) {
+	resetPVRegistryForTest()
+
+	const count = 300
+	pvs := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		name := fmt.Sprintf("BI_SUBTEST_BATCH_%03d", i)
+		setSeed(name, 0)
+		pvs = append(pvs, name)
+	}
+
+	ws := dialTestWS(t)
+	ws.send(t, map[string]interface{}{
+		"type": "subscribe", "subscription_id": "fe-1", "pvs": pvs,
+	})
+
+	ws.collectUntil(t, 5*time.Second, pvs)
+}

--- a/frontend/src/app/(modules)/l4-opcpa/components/l4-opcpa-view.tsx
+++ b/frontend/src/app/(modules)/l4-opcpa/components/l4-opcpa-view.tsx
@@ -20,7 +20,9 @@ interface L4OpcpaViewProps {
 export const L4OpcpaView: FC<L4OpcpaViewProps> = ({ specs }) => {
   const { isConnected } = useWebSocketContext()
   return (
-    <div className={styles.page}>
+    // data-palette drives the goggles token block in globals.css, and
+    // CogToggle copies it onto panels it portals to <body>.
+    <div className={styles.page} data-palette="goggles">
       <div className={styles.stickyHeader}>
         <header className={styles.header}>
           <h1 className={styles.title}>L4 OPCPA</h1>

--- a/frontend/src/app/(modules)/l4-opcpa/page.module.css
+++ b/frontend/src/app/(modules)/l4-opcpa/page.module.css
@@ -1,15 +1,7 @@
+/* The goggles palette itself lives in globals.css under
+ * [data-palette='goggles'] — see the note there: it has to be reachable from
+ * panels this page portals to <body>, which a .page-scoped block is not. */
 .page {
-  --color-surface-lighter: var(--color-positive-neutral);
-  --color-surface-light: var(--color-negative-neutral);
-  --color-surface: var(--color-negative-neutral);
-  --color-border: var(--color-text);
-  --color-gray-800: var(--color-text);
-  --color-success-light: var(--color-positive-important);
-  --color-success: var(--color-positive-important);
-  --color-success-dark: var(--color-text);
-  --color-error-light: var(--color-negative-important);
-  --color-error: var(--color-negative-important);
-  --color-error-dark: var(--color-text);
   --header-stack-height: 2rem;
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/(modules)/l4-opcpa/page.module.css
+++ b/frontend/src/app/(modules)/l4-opcpa/page.module.css
@@ -1,4 +1,15 @@
 .page {
+  --color-surface-lighter: var(--color-positive-neutral);
+  --color-surface-light: var(--color-negative-neutral);
+  --color-surface: var(--color-negative-neutral);
+  --color-border: var(--color-text);
+  --color-gray-800: var(--color-text);
+  --color-success-light: var(--color-positive-important);
+  --color-success: var(--color-positive-important);
+  --color-success-dark: var(--color-text);
+  --color-error-light: var(--color-negative-important);
+  --color-error: var(--color-negative-important);
+  --color-error-dark: var(--color-text);
   --header-stack-height: 2rem;
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -89,6 +89,38 @@
   --spacing-unit: 0.25rem;
 }
 
+/* Laser-goggles palette. Operators wear safety goggles that filter parts of the
+ * spectrum, so pages inside the laser hall re-map the semantic tokens onto the
+ * four approved tones (see the ColorLegend on the L4 OPCPA page).
+ *
+ * Scoped to an attribute rather than a page class on purpose: the panel a
+ * CogToggle opens is portaled to <body>, outside any page element, and would
+ * otherwise fall back to the global tokens — showing write errors in the
+ * #e91004 red this palette exists to avoid. CogToggle mirrors the nearest
+ * ancestor's data-palette onto its floating panel.
+ *
+ * The `-light`/base variants are fills; the `-dark` variants are used as text
+ * and border colours by the controls, so they collapse to black — bright fill
+ * colours are unreadable as text on a white surface. */
+[data-palette='goggles'] {
+  --color-surface-lighter: var(--color-positive-neutral);
+  --color-surface-light: var(--color-negative-neutral);
+  --color-surface: var(--color-negative-neutral);
+  --color-border: var(--color-text);
+  --color-gray-800: var(--color-text);
+  --color-success-light: var(--color-positive-important);
+  --color-success: var(--color-positive-important);
+  --color-success-dark: var(--color-text);
+  --color-error-light: var(--color-negative-important);
+  --color-error: var(--color-negative-important);
+  --color-error-dark: var(--color-text);
+  /* Amber is not one of the approved tones: a warning is "negative neutral",
+   * which is what the legend shows for the chiller warn cells. */
+  --color-warning-light: var(--color-negative-neutral);
+  --color-warning: var(--color-negative-neutral);
+  --color-warning-dark: var(--color-text);
+}
+
 *,
 *::before,
 *::after {
@@ -127,8 +159,13 @@ a {
 }
 
 html {
-  font-size: clamp(12.5px, 0.5vw + 4.5px, 18px); /* fluid base unit so the fully rem-based UI adapts across phones -> monitors -> TVs. 12.5px floor (readable, and 5 panels fit in one row at 1600px), scaling to 18px on large/4K displays for across-room readability. Panels, gaps, sidebar and text all scale together, so nothing truncates. Browser zoom (Ctrl +/-) still works on top of this. */
-  font-family: 'Roboto Condensed', 'Arial Narrow', 'Roboto', system-ui, sans-serif; /* narrow fallbacks: if Roboto Condensed fails to load, degrade to a condensed-ish font instead of wide sans-serif (which overflows and truncates the fixed-width labels) */
+  font-size: clamp(
+    12.5px,
+    0.5vw + 4.5px,
+    18px
+  ); /* fluid base unit so the fully rem-based UI adapts across phones -> monitors -> TVs. 12.5px floor (readable, and 5 panels fit in one row at 1600px), scaling to 18px on large/4K displays for across-room readability. Panels, gaps, sidebar and text all scale together, so nothing truncates. Browser zoom (Ctrl +/-) still works on top of this. */
+  font-family:
+    'Roboto Condensed', 'Arial Narrow', 'Roboto', system-ui, sans-serif; /* narrow fallbacks: if Roboto Condensed fails to load, degrade to a condensed-ish font instead of wide sans-serif (which overflows and truncates the fixed-width labels) */
   background: var(--color-background);
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -15,6 +15,11 @@
   --color-gray-900: #212121;
   --color-black: #000;
 
+  --color-positive-neutral: #ffffff;
+  --color-negative-neutral: #e8e8e8;
+  --color-positive-important: #00ff59;
+  --color-negative-important: #ff00c8;
+
   /* Semantic colors built on the grayscale palette */
   --color-background: var(--color-gray-500);
   --color-surface-lighter: var(--color-gray-200);

--- a/frontend/src/components/hmi/controls/CogToggle.test.tsx
+++ b/frontend/src/components/hmi/controls/CogToggle.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CogToggle } from './CogToggle'
+
+const floatingPanelOf = (child: HTMLElement) =>
+  child.closest('[data-floating="true"]')
+
+describe('CogToggle', () => {
+  it('carries the page palette onto the panel it portals to <body>', async () => {
+    const user = userEvent.setup()
+    render(
+      <div data-palette="goggles">
+        <CogToggle ariaLabel="Actions">
+          <span>panel content</span>
+        </CogToggle>
+      </div>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }))
+
+    const panel = floatingPanelOf(screen.getByText('panel content'))
+    // Portaled out of the palette scope: without the mirrored attribute the
+    // panel would fall back to the global (non-goggles) colour tokens.
+    expect(panel?.parentElement).toBe(document.body)
+    expect(panel).toHaveAttribute('data-palette', 'goggles')
+  })
+
+  it('leaves the panel unstyled by a palette outside a palette scope', async () => {
+    const user = userEvent.setup()
+    render(
+      <CogToggle ariaLabel="Actions">
+        <span>panel content</span>
+      </CogToggle>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }))
+
+    const panel = floatingPanelOf(screen.getByText('panel content'))
+    expect(panel).not.toHaveAttribute('data-palette')
+  })
+
+  it('keeps an inline panel in normal flow, where it inherits the palette', async () => {
+    const user = userEvent.setup()
+    render(
+      <div data-palette="goggles">
+        <CogToggle ariaLabel="Actions" inlineLabel="General Actions">
+          <span>panel content</span>
+        </CogToggle>
+      </div>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }))
+
+    const content = screen.getByText('panel content')
+    expect(floatingPanelOf(content)).toBeNull()
+    expect(content.closest('[data-palette="goggles"]')).not.toBeNull()
+  })
+})

--- a/frontend/src/components/hmi/controls/CogToggle.tsx
+++ b/frontend/src/components/hmi/controls/CogToggle.tsx
@@ -57,6 +57,7 @@ export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
   const isInline = Boolean(inlineLabel)
   const [open, setOpen] = useState(false)
   const [pos, setPos] = useState<{ top: number; right: number } | null>(null)
+  const [palette, setPalette] = useState<string | null>(null)
   const wrapperRef = useRef<HTMLSpanElement | null>(null)
   const buttonRef = useRef<HTMLButtonElement | null>(null)
   const panelRef = useRef<HTMLDivElement | null>(null)
@@ -86,6 +87,17 @@ export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
     window.addEventListener('mousedown', onDown)
     return () => window.removeEventListener('mousedown', onDown)
   }, [open, close])
+
+  // A page can re-map the colour tokens on its root element (the L4 OPCPA
+  // goggles palette does). The floating panel is portaled to <body>, outside
+  // that scope, so it has to carry the page's palette itself — otherwise write
+  // controls inside a dropdown fall back to the global tokens and show errors
+  // in a colour the palette exists to avoid.
+  useLayoutEffect(() => {
+    if (!open || isInline) return
+    const scope = wrapperRef.current?.closest('[data-palette]')
+    setPalette(scope?.getAttribute('data-palette') ?? null)
+  }, [open, isInline])
 
   // Position the floating dropdown: fixed, below the button, right-aligned to it,
   // flipped above if it would overflow the viewport bottom. Reposition on scroll
@@ -121,6 +133,7 @@ export const CogToggle: FC<PropsWithChildren<CogToggleProps>> = ({
         className={styles.panel}
         data-inline={isInline ? 'true' : 'false'}
         data-floating={isInline ? undefined : 'true'}
+        data-palette={isInline ? undefined : (palette ?? undefined)}
         style={
           isInline
             ? undefined

--- a/frontend/src/components/hmi/laser-panel/sections.module.css
+++ b/frontend/src/components/hmi/laser-panel/sections.module.css
@@ -53,7 +53,7 @@
   justify-content: flex-end;
   background: var(--color-surface-lighter);
   border: 1px solid var(--color-border);
-  padding: 0.0625rem 0.25rem;
+  padding: 0;
   min-height: var(--hmi-row-min-h);
   min-width: 0;
   overflow: hidden;
@@ -413,8 +413,13 @@
 
 /* CSI-783: chiller cell state rendering. One tone per derived CellKind. */
 .cellState {
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
   width: 100%;
+  padding: 0.0625rem 0.25rem;
+  box-sizing: border-box;
   text-align: center;
   font-size: var(--hmi-font-size);
   font-weight: 700;


### PR DESCRIPTION
Updated the L4 OPCPA colors to match the latest approved goggles reference (`image-20260813-123124.png`).

Changes:
- updated the neutral and important-state colors
- kept the normal page background instead of applying white to the full content area
- removed the white inset around chiller warning/error values so the state color fills the cell
- updated the local Go mock to accept the batched PV subscription format used by the frontend

I tested this with the Docker Compose setup on `http://localhost:8082`. The NL2 values populate, the controls respond, and the chiller error state fills the complete cell.

The GUI changes and mock-backend compatibility fix are in separate commits so they can be reviewed independently.
